### PR TITLE
✨ ヘッダーを作成し、アイコンとタイトルを表示 (#17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "@mui/icons-material": "^6.1.1",
         "@mui/material": "^6.1.1",
         "next": "14.2.10",
         "react": "^18",
@@ -580,6 +581,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.1.1.tgz",
+      "integrity": "sha512-sy/YKwcLPW8VcacNP2uWMYR9xyWuwO9NN9FXuGEU90bRshBXj8pdKk+joe3TCW7oviVS3zXLHlc94wQ0jNsQRQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.1.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@mui/icons-material": "^6.1.1",
     "@mui/material": "^6.1.1",
     "next": "14.2.10",
     "react": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { Header } from '@/components/layouts/Header/Header';
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -28,6 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/src/components/layouts/Header/Header.tsx
+++ b/src/components/layouts/Header/Header.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { AppBar, Box, Toolbar, Typography } from '@mui/material';
+import StarIcon from '@mui/icons-material/Star';
+
+export const Header = () => {
+  const HeaderTitle = '家計簿くん';
+
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar
+        position='fixed'
+        sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+      >
+        <Toolbar>
+            {/* 色を付けたり、ルートへのリンクを付けたり行う。 */}
+            <StarIcon/>
+            <Typography variant='h6' >{HeaderTitle}</Typography>
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+};


### PR DESCRIPTION
## 概要
ヘッダーを作成し、アイコンとタイトルを表示させた。<br>
アイコンは`@mui/icons-material`をインストールして、`StarIcon`を使用している。

## 関連タスク
Closes #17 

## 動作確認
<img width="828" alt="スクリーンショット 2024-09-21 2 58 52" src="https://github.com/user-attachments/assets/d506e803-6828-4b61-a3c8-055385612eff">
