### PR TITLE
🗃️ 予算のseedingを行った (#40)

### DIFF
--- a/prisma/migrations/20240927114326_2024_9_27/migration.sql
+++ b/prisma/migrations/20240927114326_2024_9_27/migration.sql
@@ -1,3 +1,0 @@
--- AlterTable
-ALTER TABLE "categories" ALTER COLUMN "id" DROP DEFAULT;
-DROP SEQUENCE "categories_id_seq";

--- a/prisma/migrations/20240927130002_initial_schema/migration.sql
+++ b/prisma/migrations/20240927130002_initial_schema/migration.sql
@@ -26,7 +26,7 @@ CREATE TABLE "expenses" (
 
 -- CreateTable
 CREATE TABLE "categories" (
-    "id" SERIAL NOT NULL,
+    "id" INTEGER NOT NULL,
     "name" TEXT NOT NULL,
 
     CONSTRAINT "categories_pkey" PRIMARY KEY ("id")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -32,6 +32,7 @@ async function main() {
         passwordDigest: faker.internet.password()
       },
     });
+    console.log(`Created user named ${newUser.name}`);
 
     for (let i = 0; i < 20; i++){
       // 出費の作成
@@ -44,7 +45,36 @@ async function main() {
           categoryId: Math.floor(Math.random() * 9) + 1
         },
       });
-    }}
+    }
+    console.log('Created Expenses');
+
+    // 予算の作成
+    // 8月分
+    for (let i = 1; i < 10; i++){
+      const newBudget = await prisma.budget.create({
+        data: {
+          amount: parseInt(faker.finance.amount({ min: 10000, max: 30000, dec: 0 })),
+          year_month: new Date(2024, 7, 15),
+          userId: newUser.id,
+          categoryId: i,
+        }
+      })
+      console.log(`Created newBudget ${newBudget.year_month}`);
+    }
+
+    // 9月分
+    for (let i = 1; i < 10; i++){
+      const newBudget = await prisma.budget.create({
+        data: {
+          amount: parseInt(faker.finance.amount({ min: 10000, max: 30000, dec: 0 })),
+          year_month: new Date(2024, 8, 15),
+          userId: newUser.id,
+          categoryId: i,
+        }
+      })
+      console.log(`Created newBudget ${newBudget.year_month}`);
+    }
+  }
 
 }
 main()


### PR DESCRIPTION
## 概要
予算のseedingを行った。

## 詳細
8月と9月分の予算を作成した。
各カテゴリーごとに作成した。

## 関連タスク
Closes # 40

## 補足
prismaがUTCタイムでの保存しかできずに、`new Date(2024, 8)`(jsのdatetimeは月が0から始まるため、8は9月を意味する。)とすると、`2024-08-31-15:00`のようになる。
今回、yearとmonthのみを考えればいいので、ダミーデータには、9月の予算のyear_monthを`new Date(2024, 8, 15)`としている。

## 動作確認
<img width="1407" alt="スクリーンショット 2024-09-27 22 08 16" src="https://github.com/user-attachments/assets/a2e4782c-8b7f-4e17-b0e6-11a127296aef">

