### PR TITLE
現在ある出費月の範囲をstring[]で取得した (#56)

### DIFF
--- a/src/_components/layouts/Sidebar/Sidebar.tsx
+++ b/src/_components/layouts/Sidebar/Sidebar.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 import * as React from "react";
+import { getFirstAndLastExpense } from "@/lib/db/index";
 import {
   Box,
   Drawer,
@@ -16,23 +15,27 @@ import {
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 
 const drawerWidth = "20%";
-const date = "9月22日";
-const proverb = "時は金なり";
 
-const card = (
-  <React.Fragment>
-    <CardContent>
-      <Typography gutterBottom sx={{ color: "text.secondary", fontSize: 14 }}>
-        {date}の一言
-      </Typography>
-      <Typography variant="h5" component="div">
-        {proverb}
-      </Typography>
-    </CardContent>
-  </React.Fragment>
-);
+export const Sidebar = async () => {
+  const date = "9月22日";
+  const proverb = "時は金なり";
+  const userId = "30d06a0b-dcb9-4060-911e-d15b50e2b7e0";
 
-export function Sidebar() {
+  const firstLastExpense = await getFirstAndLastExpense(userId);
+
+  const card = (
+    <React.Fragment>
+      <CardContent>
+        <Typography gutterBottom sx={{ color: "text.secondary", fontSize: 14 }}>
+          {date}の一言
+        </Typography>
+        <Typography variant="h5" component="div">
+          {proverb}
+        </Typography>
+      </CardContent>
+    </React.Fragment>
+  );
+
   return (
     <Drawer
       variant="permanent"
@@ -60,4 +63,4 @@ export function Sidebar() {
       </Box>
     </Drawer>
   );
-}
+};

--- a/src/_components/layouts/Sidebar/Sidebar.tsx
+++ b/src/_components/layouts/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { getFirstAndLastExpense } from "@/lib/db/index";
+import { getFirstAndLastExpenseDate } from "@/lib/db/index";
 import {
   Box,
   Drawer,
@@ -13,15 +13,50 @@ import {
   Typography,
 } from "@mui/material";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import { FirstAndLastExpenseDate } from "@/types";
 
 const drawerWidth = "20%";
+
+const getMonthsInRange = (
+  firstAndLastExpenseDate: FirstAndLastExpenseDate
+): string[] => {
+  const monthsInRange: string[] = [];
+
+  if (firstAndLastExpenseDate._min.date && firstAndLastExpenseDate._max.date) {
+    // minDateからmaxDateまでの月を取得
+    let currentDate = new Date(
+      firstAndLastExpenseDate._min.date.getFullYear(),
+      firstAndLastExpenseDate._min.date.getMonth(),
+      1
+    );
+    const endDate = new Date(
+      firstAndLastExpenseDate._max.date.getFullYear(),
+      firstAndLastExpenseDate._max.date.getMonth(),
+      1
+    );
+
+    while (currentDate <= endDate) {
+      // 年と月を取得し、"YYYY-MM or M" の形式で格納
+      const year = currentDate.getFullYear();
+      const month = (currentDate.getMonth() + 1).toString();
+      monthsInRange.push(`${year}-${month}`);
+
+      // 次の月に移動
+      currentDate.setMonth(currentDate.getMonth() + 1);
+    }
+  }
+  return monthsInRange;
+};
 
 export const Sidebar = async () => {
   const date = "9月22日";
   const proverb = "時は金なり";
   const userId = "30d06a0b-dcb9-4060-911e-d15b50e2b7e0";
 
-  const firstLastExpense = await getFirstAndLastExpense(userId);
+  const firstLastExpense = await getFirstAndLastExpenseDate(userId);
+
+  const monthsInRange = getMonthsInRange(firstLastExpense);
+  console.log(monthsInRange);
 
   const card = (
     <React.Fragment>

--- a/src/lib/db/expense.ts
+++ b/src/lib/db/expense.ts
@@ -2,13 +2,7 @@
 
 import prisma from "@/lib/prisma";
 import { cache } from "react";
-import { Expense } from "@/types";
-
-// このページでしか使わない型定義はここに記載
-type getFirstAndLastExpenseResponse = {
-  _min: { date: Date | null };
-  _max: { date: Date | null };
-};
+import { Expense, FirstAndLastExpenseDate } from "@/types";
 
 // 指定した月の出費を取得する
 export const getMonthExpenses = cache(
@@ -26,8 +20,8 @@ export const getMonthExpenses = cache(
 );
 
 // 出費の最初のデータと最後のデータを取得する
-export const getFirstAndLastExpense = cache(
-  async (userId: string): Promise<getFirstAndLastExpenseResponse> => {
+export const getFirstAndLastExpenseDate = cache(
+  async (userId: string): Promise<FirstAndLastExpenseDate> => {
     return await prisma.expense.aggregate({
       where: {
         userId: userId,

--- a/src/lib/db/expense.ts
+++ b/src/lib/db/expense.ts
@@ -4,6 +4,12 @@ import prisma from "@/lib/prisma";
 import { cache } from "react";
 import { Expense } from "@/types";
 
+// このページでしか使わない型定義はここに記載
+type getFirstAndLastExpenseResponse = {
+  _min: { date: Date | null };
+  _max: { date: Date | null };
+};
+
 // 指定した月の出費を取得する
 export const getMonthExpenses = cache(
   async (userId: string, firstDay: Date, lastDay: Date): Promise<Expense[]> => {
@@ -14,6 +20,23 @@ export const getMonthExpenses = cache(
           lt: lastDay,
         },
         userId: userId,
+      },
+    });
+  }
+);
+
+// 出費の最初のデータと最後のデータを取得する
+export const getFirstAndLastExpense = cache(
+  async (userId: string): Promise<getFirstAndLastExpenseResponse> => {
+    return await prisma.expense.aggregate({
+      where: {
+        userId: userId,
+      },
+      _min: {
+        date: true,
+      },
+      _max: {
+        date: true,
       },
     });
   }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,5 +1,10 @@
-import { getMonthBudgets } from "@/lib/db/budget"
-import { getMonthExpenses, getFirstAndLastExpense } from "@/lib/db/expense"
-import { getCategories } from "@/lib/db/category"
+import { getMonthBudgets } from "@/lib/db/budget";
+import { getMonthExpenses, getFirstAndLastExpenseDate } from "@/lib/db/expense";
+import { getCategories } from "@/lib/db/category";
 
-export { getMonthBudgets, getMonthExpenses, getFirstAndLastExpense, getCategories}
+export {
+  getMonthBudgets,
+  getMonthExpenses,
+  getFirstAndLastExpenseDate,
+  getCategories,
+};

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,5 +1,5 @@
 import { getMonthBudgets } from "@/lib/db/budget"
-import { getMonthExpenses } from "@/lib/db/expense"
+import { getMonthExpenses, getFirstAndLastExpense } from "@/lib/db/expense"
 import { getCategories } from "@/lib/db/category"
 
-export { getMonthBudgets, getMonthExpenses, getCategories}
+export { getMonthBudgets, getMonthExpenses, getFirstAndLastExpense, getCategories}

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -8,3 +8,8 @@ export type Expense = {
   userId: string;
   categoryId: number;
 };
+
+export type FirstAndLastExpenseDate = {
+  _min: { date: Date | null };
+  _max: { date: Date | null };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
-import { Budget } from "@/types/budget"
-import { Expense } from "@/types/expense"
-import { Category } from "@/types/category"
+import { Budget } from "@/types/budget";
+import { Expense, FirstAndLastExpenseDate } from "@/types/expense";
+import { Category } from "@/types/category";
 
-export type {Budget, Expense, Category}
+export type { Budget, Expense, FirstAndLastExpenseDate, Category };


### PR DESCRIPTION
## 概要
現在ある出費月の範囲を["YYY-MM or M"]で取得するようにした。

## 実装詳細
- Prismaのaggregateを使って、_miniと_maxで出費の最初の月と最後の月を取得した
  - [✨1番初めの出費と最後の出費を取得できるようにした (#56 #54)](https://github.com/AyumuOgasawara/receipt-scanner/commit/2f3981575211a59140dac7c40727a8a06694f100)
- [♻️ FirstAndLastExpenseDateの方をglobalで使用したいために、exportできるようにし、わかりやすいように変数名を変更した(#56 #54)](https://github.com/AyumuOgasawara/receipt-scanner/commit/16d129a83335434d2c1edc8e606b779c030d4282)
- 取得した最初の月から１ヶ月づつ繰り上げて最後の月までwhileを回し、出費月範囲を"YYYY-MM or M"の形で取得した。
- [✨Siderbarで出費月の範囲の全ての月を取得し"YYYY-MM or M"の形でリストに入れた (#54 #56)](https://github.com/AyumuOgasawara/receipt-scanner/commit/69e216009984e298256a556f877623960f74612b)

## 動作確認
出費の最初の日にち：`2024-07-31T14:05:20.658Z` -> 2024年7月 (日本時間)
出費の最後の日にち：`2024-09-30T23:13:28.683Z` -> 2024年10月 (日本時間)

``` ts
const monthsInRange = getMonthsInRange(firstLastExpense);
console.log(monthsInRange);
```

[ '2024-7', '2024-8', '2024-9', '2024-10' ]

## 関連タスク
Closes #56 
