### PR TITLE
🐛 childrenを囲むBoxがheader分ずれていた部分を修正 (#51)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,9 +33,8 @@ export default function RootLayout({
         style={{ height: "100vh" }}
       >
         <Header />
-        <Toolbar />
 
-        <Box display="flex" flexDirection="row" height="100%">
+        <Box display="flex" flexDirection="row" height="100%" paddingTop={8}>
           <Box
             component="main"
             height="100%"


### PR DESCRIPTION
## 概要
childrenとsidebarを囲んでいたBoxにpaddingTopをつけることで、childrenを囲むBoxがheader分ずれていたバグを修正

## 関連タスク
Closes #51 

## 経緯
https://github.com/AyumuOgasawara/receipt-scanner/issues/51#issuecomment-2391219600

## 動作確認

https://github.com/user-attachments/assets/0487b933-c4c2-4858-b6ff-acbbb4e5fac5

