### PR TITLE
✨ 出費一覧から特定の出費をダイアログで表示するようにした (#70)

### DIFF
--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -12,6 +12,7 @@ import {
   Select,
   SelectChangeEvent,
   InputLabel,
+  useMediaQuery,
 } from "@mui/material";
 import { formatDate } from "@/utils/time";
 import { RowType } from "@/_components/features/expenses/type";
@@ -38,59 +39,90 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   };
 
   return (
-    <Box>
-      <Dialog open={open} onClose={handleClose}>
-        <DialogContent>
-          {selectedItem && (
-            <Box
-              display="flex"
-              flexDirection="column"
-              component="form"
-              sx={{ "& .MuiTextField-root": { m: 1, width: "25ch" } }}
-            >
-              <TextField
-                id="date"
-                label="日付"
-                defaultValue={formatDate(selectedItem.date, {
-                  month: true,
-                  day: true,
-                })}
-                variant="filled"
-              />
-              <TextField
-                id="store-name"
-                label="店名"
-                defaultValue={selectedItem.storeName}
-                variant="filled"
-              />
-              <TextField
-                id="amount"
-                label="金額"
-                defaultValue={selectedItem.amount}
-                variant="filled"
-              />
-              <FormControl sx={{ m: 1, minWidth: 120 }}>
-                <InputLabel variant="filled">カテゴリー</InputLabel>
-                <Select
-                  native
-                  onChange={handleChange}
+    <>
+      <Box sx={{ position: "relative" }}>
+        <Dialog
+          open={open}
+          onClose={handleClose}
+          sx={{
+            "& .MuiDialog-paper": {
+              right: "10%",
+            },
+          }}
+        >
+          <DialogContent>
+            {selectedItem && (
+              <Box
+                display="flex"
+                flexDirection="column"
+                component="form"
+                sx={{ "& .MuiTextField-root": { m: 1 } }}
+              >
+                <TextField
+                  id="date"
+                  label="日付"
+                  defaultValue={formatDate(selectedItem.date, {
+                    month: true,
+                    day: true,
+                  })}
                   variant="filled"
-                  defaultValue={selectedItem.category_id}
-                >
-                  {categories.map((category) => (
-                    <option value={category.id}>{category.name}</option>
-                  ))}
-                </Select>
-              </FormControl>
-            </Box>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose}>レシートを表示</Button>
-          <Button onClick={handleClose}>削除</Button>
-          <Button onClick={handleClose}>保存</Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
+                />
+                <TextField
+                  id="store-name"
+                  label="店名"
+                  defaultValue={selectedItem.storeName}
+                  variant="filled"
+                />
+                <TextField
+                  id="amount"
+                  label="金額"
+                  defaultValue={selectedItem.amount}
+                  variant="filled"
+                />
+                <FormControl sx={{ m: 1, minWidth: 120 }}>
+                  <InputLabel variant="filled">カテゴリー</InputLabel>
+                  <Select
+                    native
+                    onChange={handleChange}
+                    variant="filled"
+                    defaultValue={selectedItem.category_id}
+                  >
+                    {categories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.name}
+                      </option>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button
+              variant="contained"
+              sx={{ fontWeight: "bold", marginRight: "64px" }}
+              onClick={handleClose}
+            >
+              レシートを表示
+            </Button>
+            <Button
+              variant="contained"
+              sx={{ fontWeight: "bold" }}
+              color="error"
+              onClick={handleClose}
+            >
+              削除
+            </Button>
+            <Button
+              variant="contained"
+              sx={{ fontWeight: "bold" }}
+              onClick={handleClose}
+            >
+              保存
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    </>
   );
 };

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -11,20 +11,24 @@ import {
   FormControl,
   Select,
   SelectChangeEvent,
+  InputLabel,
 } from "@mui/material";
 import { formatDate } from "@/utils/time";
 import { RowType } from "@/_components/features/expenses/type";
+import { Category } from "@/types";
 
 type ExpensesDialogProps = {
   handleClose: () => void;
   open: boolean;
   selectedItem: RowType | null;
+  categories: Category[];
 };
 
 export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   handleClose,
   open,
   selectedItem,
+  categories,
 }) => {
   const [category, setCategory] = React.useState<number | undefined>(
     selectedItem?.category_id
@@ -66,18 +70,16 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
                 variant="filled"
               />
               <FormControl sx={{ m: 1, minWidth: 120 }}>
+                <InputLabel variant="filled">カテゴリー</InputLabel>
                 <Select
                   native
-                  value={category}
                   onChange={handleChange}
                   variant="filled"
                   defaultValue={selectedItem.category_id}
                 >
-                  {/* TODO: ここをカテゴリーの実際のデータを使って、mapするようにする。 */}
-                  <option aria-label="None" value="" />
-                  <option value={1}>Ten</option>
-                  <option value={2}>Twenty</option>
-                  <option value={3}>Thirty</option>
+                  {categories.map((category) => (
+                    <option value={category.id}>{category.name}</option>
+                  ))}
                 </Select>
               </FormControl>
             </Box>

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React, { FC } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Box,
+  Button,
+  FormControl,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+import { formatDate } from "@/utils/time";
+import { RowType } from "@/_components/features/expenses/type";
+
+type ExpensesDialogProps = {
+  handleClose: () => void;
+  open: boolean;
+  selectedItem: RowType | null;
+};
+
+export const ExpensesDialog: FC<ExpensesDialogProps> = ({
+  handleClose,
+  open,
+  selectedItem,
+}) => {
+  const [category, setCategory] = React.useState<number | undefined>(
+    selectedItem?.category_id
+  );
+  const handleChange = (event: SelectChangeEvent<typeof category>) => {
+    setCategory(Number(event.target.value));
+  };
+
+  return (
+    <Box>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogContent>
+          {selectedItem && (
+            <Box
+              display="flex"
+              flexDirection="column"
+              component="form"
+              sx={{ "& .MuiTextField-root": { m: 1, width: "25ch" } }}
+            >
+              <TextField
+                id="date"
+                label="日付"
+                defaultValue={formatDate(selectedItem.date, {
+                  month: true,
+                  day: true,
+                })}
+                variant="filled"
+              />
+              <TextField
+                id="store-name"
+                label="店名"
+                defaultValue={selectedItem.storeName}
+                variant="filled"
+              />
+              <TextField
+                id="amount"
+                label="金額"
+                defaultValue={selectedItem.amount}
+                variant="filled"
+              />
+              <FormControl sx={{ m: 1, minWidth: 120 }}>
+                <Select
+                  native
+                  value={category}
+                  onChange={handleChange}
+                  variant="filled"
+                  defaultValue={selectedItem.category_id}
+                >
+                  {/* TODO: ここをカテゴリーの実際のデータを使って、mapするようにする。 */}
+                  <option aria-label="None" value="" />
+                  <option value={1}>Ten</option>
+                  <option value={2}>Twenty</option>
+                  <option value={3}>Thirty</option>
+                </Select>
+              </FormControl>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>レシートを表示</Button>
+          <Button onClick={handleClose}>削除</Button>
+          <Button onClick={handleClose}>保存</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC } from "react";
+import React, { useState, FC } from "react";
 import {
   Table,
   TableBody,
@@ -12,20 +12,29 @@ import {
   Box,
 } from "@mui/material";
 import { formatDate } from "@/utils/time";
-
-type RowType = {
-  expense_id: string;
-  date: Date;
-  storeName: string;
-  amount: number;
-  category: string;
-};
+import { ExpensesDialog } from "@/_components/features/expenses";
+import { RowType } from "@/_components/features/expenses/type";
 
 type ExpensesTableProps = {
   rows: RowType[];
 };
 
 export const ExpensesTable: FC<ExpensesTableProps> = ({ rows }) => {
+  const [open, setOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<RowType | null>(null);
+
+  // 列がクリックされたときに詳細を表示する関数
+  const handleClick = (item: RowType) => {
+    setSelectedItem(item);
+    setOpen(true);
+  };
+
+  // ダイアログを閉じる関数
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedItem(null);
+  };
+
   return (
     <Box>
       <TableContainer component={Paper} style={{ maxHeight: 640 }}>
@@ -44,6 +53,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows }) => {
                 key={row.expense_id}
                 hover
                 style={{ cursor: "pointer" }}
+                onClick={() => handleClick(row)}
               >
                 <TableCell>
                   {formatDate(row.date, { month: true, day: true })}
@@ -56,6 +66,12 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows }) => {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <ExpensesDialog
+        handleClose={handleClose}
+        open={open}
+        selectedItem={selectedItem}
+      />
     </Box>
   );
 };

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -14,12 +14,14 @@ import {
 import { formatDate } from "@/utils/time";
 import { ExpensesDialog } from "@/_components/features/expenses";
 import { RowType } from "@/_components/features/expenses/type";
+import { Category } from "@/types";
 
 type ExpensesTableProps = {
   rows: RowType[];
+  categories: Category[];
 };
 
-export const ExpensesTable: FC<ExpensesTableProps> = ({ rows }) => {
+export const ExpensesTable: FC<ExpensesTableProps> = ({ rows, categories }) => {
   const [open, setOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<RowType | null>(null);
 
@@ -71,6 +73,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows }) => {
         handleClose={handleClose}
         open={open}
         selectedItem={selectedItem}
+        categories={categories}
       />
     </Box>
   );

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -38,6 +38,9 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows, categories }) => {
     setSelectedItem(null);
   };
 
+  const headers = ["日付", "店名", "金額", "カテゴリー"];
+  const tableCellStyle = { borderBottom: "solid black" };
+
   return (
     <Box>
       <TableContainer component={Paper} style={{ maxHeight: 640 }}>
@@ -50,10 +53,11 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows, categories }) => {
         >
           <TableHead>
             <TableRow>
-              <TableCell>日付</TableCell>
-              <TableCell>店名</TableCell>
-              <TableCell>金額</TableCell>
-              <TableCell>カテゴリー</TableCell>
+              {headers.map((header) => (
+                <TableCell key={header} sx={tableCellStyle}>
+                  {header}
+                </TableCell>
+              ))}
             </TableRow>
           </TableHead>
           <TableBody>

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -12,6 +12,7 @@ import {
   Box,
 } from "@mui/material";
 import { formatDate } from "@/utils/time";
+import { formatCurrency } from "@/utils/financial";
 import { ExpensesDialog } from "@/_components/features/expenses";
 import { RowType } from "@/_components/features/expenses/type";
 import { Category } from "@/types";
@@ -40,7 +41,13 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows, categories }) => {
   return (
     <Box>
       <TableContainer component={Paper} style={{ maxHeight: 640 }}>
-        <Table stickyHeader aria-label="sticky table">
+        <Table
+          stickyHeader
+          aria-label="sticky table"
+          sx={{
+            "& .MuiTableCell-root": { width: "80ch", textAlign: "center" },
+          }}
+        >
           <TableHead>
             <TableRow>
               <TableCell>日付</TableCell>
@@ -61,7 +68,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows, categories }) => {
                   {formatDate(row.date, { month: true, day: true })}
                 </TableCell>
                 <TableCell>{row.storeName}</TableCell>
-                <TableCell>{row.amount}</TableCell>
+                <TableCell>{formatCurrency(row.amount)}</TableCell>
                 <TableCell>{row.category}</TableCell>
               </TableRow>
             ))}

--- a/src/_components/features/expenses/index.tsx
+++ b/src/_components/features/expenses/index.tsx
@@ -1,3 +1,4 @@
 import { ExpensesTable } from "@/_components/features/expenses/ExpensesTable";
+import { ExpensesDialog } from "@/_components/features/expenses/ExpenseDialog";
 
-export { ExpensesTable };
+export { ExpensesTable, ExpensesDialog };

--- a/src/_components/features/expenses/type.ts
+++ b/src/_components/features/expenses/type.ts
@@ -1,0 +1,8 @@
+export type RowType = {
+  expense_id: string;
+  date: Date;
+  storeName: string;
+  amount: number;
+  category_id: number;
+  category: string;
+};

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -1,4 +1,4 @@
-import { getMonthExpensesWithCategory } from "@/lib/db";
+import { getMonthExpensesWithCategory, getCategories } from "@/lib/db";
 import { getToday, getStartAndEndOfMonth } from "@/utils/time";
 import React from "react";
 import { Box } from "@mui/material";
@@ -19,6 +19,8 @@ export default async function Page() {
     lastDay
   );
 
+  const categories = await getCategories();
+
   // 出費を特定のフォーマットにする
   const rows = monthExpensesWithCate.map((expense) => ({
     expense_id: expense.id,
@@ -30,7 +32,7 @@ export default async function Page() {
   }));
   return (
     <Box>
-      <ExpensesTable rows={rows} />
+      <ExpensesTable rows={rows} categories={categories} />
     </Box>
   );
 }

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -25,6 +25,7 @@ export default async function Page() {
     date: expense.date,
     storeName: expense.storeName,
     amount: expense.amount,
+    category_id: expense.categoryId,
     category: expense.category.name,
   }));
   return (


### PR DESCRIPTION
## 概要
出費一覧から、特定の出費を選択するとダイアログを出して詳細を表示するようにした

## 実装詳細
-  [✨ 出費一覧から列を選択するとその列の詳細画面がダイアログで出るようにした(#66)](https://github.com/AyumuOgasawara/receipt-scanner/commit/c49441af1ff5e1d3196f20585c4cbdb2ef7354c8)
- [✨ カテゴリーをドロップダウンで選べれるようにした (#70)](https://github.com/AyumuOgasawara/receipt-scanner/commit/5e9e7297e848e7a7cda506f09466dc3d0aace757)
- [💄 出費一覧と詳細ダイアログのUIを整えた (#70)](https://github.com/AyumuOgasawara/receipt-scanner/commit/3426c1ea0647eaae54105b96fd7608debdbd9078)

## 動作確認
<img width="1178" alt="スクリーンショット 2024-10-06 4 01 39" src="https://github.com/user-attachments/assets/89dad27b-5eb5-4cd9-9311-b00dc7825951">
