### PR TITLE
🐛 FormControlの中に一つのSelectが入るようにした (#71)

### DIFF
--- a/src/_components/layouts/Sidebar/Sidebar.tsx
+++ b/src/_components/layouts/Sidebar/Sidebar.tsx
@@ -96,10 +96,12 @@ export const Sidebar = async () => {
           <MenuItem value={"expenses"}>全ての出費</MenuItem>
           <MenuItem value={"budgets"}>予算の編集</MenuItem>
         </Select>
-        <Button variant="outlined" sx={{}}>
-          <AddCircleOutlineIcon sx={{ m: 2 }} />
-          出費を追加
-        </Button>
+      </FormControl>
+      <Button variant="outlined" sx={{}}>
+        <AddCircleOutlineIcon sx={{ m: 2 }} />
+        出費を追加
+      </Button>
+      <FormControl sx={{ m: 1, minWidth: 80, textAlign: "center" }}>
         <Select
           // 最後の月をでファルとに選択 → 必然的に今月
           defaultValue={dateDropdownElements[


### PR DESCRIPTION
## 概要
以下のエラーメッセージがコンソールに出ていたため、FormControlの中に一つのSelectが入るようにしエラーをなくした

## エラーイメージ
<img width="295" alt="スクリーンショット 2024-10-06 1 10 05" src="https://github.com/user-attachments/assets/9398f24a-ef96-4866-b3d3-fcfcfd259ef5">

## 実装詳細
FormControlの下に二つのSelectを入れていたが、FormControlには一つのSelectしか入らなかったため、修正した

## 動作確認
<img width="603" alt="スクリーンショット 2024-10-06 4 34 05" src="https://github.com/user-attachments/assets/efed1134-ed2e-4d34-9dad-865359cb804f">

## 関連タスク
Closes #71 