### PR TITLE
⚡️ 出費の詳細ダイアログの項目を制御した(#76)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "@mui/icons-material": "^6.1.1",
         "@mui/material": "^6.1.1",
         "@mui/x-charts": "^7.18.0",
+        "@mui/x-date-pickers": "^7.19.0",
         "@prisma/client": "^5.19.1",
+        "dayjs": "^1.11.13",
         "next": "14.2.13",
         "react": "^18",
         "react-dom": "^18"
@@ -965,6 +967,108 @@
       }
     },
     "node_modules/@mui/x-charts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.19.0.tgz",
+      "integrity": "sha512-OIQ+IxgL2Si7DP68sw1ImcHXZtAmklHcyo/oqP4HuJZ2lVnP5sJkoXrksfumL1wjWKJkecONFz3unAqViKXzCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "@mui/utils": "^5.16.6",
+        "@mui/x-internals": "7.18.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/@mui/utils": {
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.6.tgz",
+      "integrity": "sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/types": "^7.2.15",
+        "@types/prop-types": "^15.7.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
@@ -2472,6 +2576,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "@mui/icons-material": "^6.1.1",
     "@mui/material": "^6.1.1",
     "@mui/x-charts": "^7.18.0",
+    "@mui/x-date-pickers": "^7.19.0",
     "@prisma/client": "^5.19.1",
+    "dayjs": "^1.11.13",
     "next": "14.2.13",
     "react": "^18",
     "react-dom": "^18"

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -12,7 +12,8 @@ import {
   Select,
   SelectChangeEvent,
   InputLabel,
-  useMediaQuery,
+  FilledInput,
+  InputAdornment,
 } from "@mui/material";
 import { formatDate } from "@/utils/time";
 import { RowType } from "@/_components/features/expenses/type";
@@ -73,12 +74,16 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
                   defaultValue={selectedItem.storeName}
                   variant="filled"
                 />
-                <TextField
-                  id="amount"
-                  label="金額"
-                  defaultValue={selectedItem.amount}
-                  variant="filled"
-                />
+                <FormControl sx={{ m: 1, minWidth: 120 }} variant="filled">
+                  <InputLabel id="amount">金額</InputLabel>
+                  <FilledInput
+                    startAdornment={
+                      <InputAdornment position="start">¥</InputAdornment>
+                    }
+                    type="number"
+                    defaultValue={selectedItem.amount}
+                  />
+                </FormControl>
                 <FormControl sx={{ m: 1, minWidth: 120 }}>
                   <InputLabel variant="filled">カテゴリー</InputLabel>
                   <Select

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -15,9 +15,12 @@ import {
   FilledInput,
   InputAdornment,
 } from "@mui/material";
-import { formatDate } from "@/utils/time";
 import { RowType } from "@/_components/features/expenses/type";
 import { Category } from "@/types";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import dayjs from "dayjs";
 
 type ExpensesDialogProps = {
   handleClose: () => void;
@@ -59,15 +62,23 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
                 component="form"
                 sx={{ "& .MuiTextField-root": { m: 1 } }}
               >
-                <TextField
-                  id="date"
-                  label="日付"
-                  defaultValue={formatDate(selectedItem.date, {
-                    month: true,
-                    day: true,
-                  })}
-                  variant="filled"
-                />
+                <LocalizationProvider dateAdapter={AdapterDayjs}>
+                  <DemoContainer components={["DatePicker"]}>
+                    <DatePicker
+                      defaultValue={dayjs(selectedItem.date)}
+                      label="日付"
+                      slotProps={{
+                        calendarHeader: {
+                          format: "YYYY年MM月", // カレンダーの年月の部分
+                        },
+                        textField: {
+                          variant: "filled",
+                        },
+                      }}
+                      format="YYYY年MM月DD" // 入力欄
+                    />
+                  </DemoContainer>
+                </LocalizationProvider>
                 <TextField
                   id="store-name"
                   label="店名"


### PR DESCRIPTION
## 概要
出費の詳細ダイアログの項目を制御した。
- 日付項目をDate Pickerを使い、日付しか選択できないようにした。
- 金額の項目を数字しか入れれないようにした

## 実装詳細
- [⚡️ 金額に円マークをつけ、数字しか入力できないようにした (#76)](https://github.com/AyumuOgasawara/receipt-scanner/commit/8cefb159fa7c791c98c779a12f395a44932554f3)
  - `InputAdornment`を使用して、円マークを先頭につけた
  - `type="number"`をつけることで、数字しか入力できなくした
- [⚡️ 日付の選択でDate Pickerを使用するようにし日本語表記にした (#76)](https://github.com/AyumuOgasawara/receipt-scanner/commit/059583f72f97a747cb541b28372680342039cf6c)
  - `x-date-pickers`と`dayjs`を使った
  - `calendarHeader: {format: "YYYY年MM月", // カレンダーの年月の部分}`、`format="YYYY年MM月DD" `で日本語表記にした

## 動作確認
<img width="377" alt="スクリーンショット 2024-10-06 12 23 24" src="https://github.com/user-attachments/assets/2b5c97f4-d347-473f-806e-2e0dc5cad3b4">

https://github.com/user-attachments/assets/7bc0261a-31b3-493b-a35a-0a80d544c615




## 補足
金額はeを数字として扱うようになっている。
