### PR TITLE
出費詳細ページで更新ボタンの実装を行う。

### DIFF
--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -21,7 +21,10 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import { RowType } from "@/_components/features/expenses/type";
 import { Category } from "@/types";
-import { formatAndUpdateExpense } from "@/_components/features/expenses/expensesServer";
+import {
+  formatAndUpdateExpense,
+  getAndFormatExpenses,
+} from "@/_components/features/expenses/expensesServer";
 
 type ExpensesDialogProps = {
   handleClose: () => void;
@@ -29,6 +32,9 @@ type ExpensesDialogProps = {
   selectedItem: RowType | null;
   categories: Category[];
   setRows: React.Dispatch<React.SetStateAction<RowType[]>>;
+  userId: string;
+  firstDay: Date;
+  lastDay: Date;
 };
 
 export const ExpensesDialog: FC<ExpensesDialogProps> = ({
@@ -37,6 +43,9 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   selectedItem,
   categories,
   setRows,
+  userId,
+  firstDay,
+  lastDay,
 }) => {
   const dateRef = useRef<HTMLInputElement>(null);
   const storeNameRef = useRef<HTMLInputElement>(null);
@@ -67,6 +76,16 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
       // TODO: エラーの対応を考える
       console.log("The selected values are invalid");
     }
+
+    const setFormattedRows = async () => {
+      const formattedExpenses = await getAndFormatExpenses(
+        userId,
+        firstDay,
+        lastDay
+      );
+      setRows(formattedExpenses);
+    };
+    setFormattedRows();
 
     handleClose();
   };

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC } from "react";
+import React, { FC, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -35,13 +35,26 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   selectedItem,
   categories,
 }) => {
-  const [category, setCategory] = React.useState<number | undefined>(
-    selectedItem?.category_id
-  );
-  const handleChange = (event: SelectChangeEvent<typeof category>) => {
-    setCategory(Number(event.target.value));
-  };
+  const dateRef = useRef<HTMLInputElement>(null);
+  const storeNameRef = useRef<HTMLInputElement>(null);
+  const amountRef = useRef<HTMLInputElement>(null);
+  const categoryRef = useRef<HTMLInputElement>(null);
 
+  const upddateExpenses = () => {
+    const updatedData = {
+      expense_id: selectedItem?.expense_id,
+      date: dateRef.current?.value,
+      storeName: storeNameRef.current?.value,
+      amount: Number(amountRef.current?.value),
+      category_id: categoryRef.current?.value,
+    };
+
+    // Log the updated data to the console
+    console.log("Updated data:", updatedData);
+
+    // Optionally: Close the dialog after logging
+    handleClose();
+  };
   return (
     <>
       <Box sx={{ position: "relative" }}>
@@ -76,6 +89,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
                         },
                       }}
                       format="YYYY年MM月DD" // 入力欄
+                      inputRef={dateRef}
                     />
                   </DemoContainer>
                 </LocalizationProvider>
@@ -84,6 +98,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
                   label="店名"
                   defaultValue={selectedItem.storeName}
                   variant="filled"
+                  inputRef={storeNameRef}
                 />
                 <FormControl sx={{ m: 1, minWidth: 120 }} variant="filled">
                   <InputLabel id="amount">金額</InputLabel>
@@ -93,15 +108,16 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
                     }
                     type="number"
                     defaultValue={selectedItem.amount}
+                    inputRef={amountRef}
                   />
                 </FormControl>
                 <FormControl sx={{ m: 1, minWidth: 120 }}>
                   <InputLabel variant="filled">カテゴリー</InputLabel>
                   <Select
                     native
-                    onChange={handleChange}
                     variant="filled"
                     defaultValue={selectedItem.category_id}
+                    inputRef={categoryRef}
                   >
                     {categories.map((category) => (
                       <option key={category.id} value={category.id}>
@@ -132,9 +148,9 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
             <Button
               variant="contained"
               sx={{ fontWeight: "bold" }}
-              onClick={handleClose}
+              onClick={upddateExpenses}
             >
-              保存
+              更新
             </Button>
           </DialogActions>
         </Dialog>

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -31,10 +31,14 @@ type ExpensesDialogProps = {
   open: boolean;
   selectedItem: RowType | null;
   categories: Category[];
-  setRows: React.Dispatch<React.SetStateAction<RowType[]>>;
   userId: string;
   firstDay: Date;
   lastDay: Date;
+  getExpensesAndSetRows: (
+    userId: string,
+    firstDay: Date,
+    lastDay: Date
+  ) => Promise<void>;
 };
 
 export const ExpensesDialog: FC<ExpensesDialogProps> = ({
@@ -42,10 +46,10 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   open,
   selectedItem,
   categories,
-  setRows,
   userId,
   firstDay,
   lastDay,
+  getExpensesAndSetRows,
 }) => {
   const dateRef = useRef<HTMLInputElement>(null);
   const storeNameRef = useRef<HTMLInputElement>(null);
@@ -77,15 +81,8 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
       console.log("The selected values are invalid");
     }
 
-    const setFormattedRows = async () => {
-      const formattedExpenses = await getAndFormatExpenses(
-        userId,
-        firstDay,
-        lastDay
-      );
-      setRows(formattedExpenses);
-    };
-    setFormattedRows();
+    // データを再取得し、rowsをセットする
+    getExpensesAndSetRows(userId, firstDay, lastDay);
 
     handleClose();
   };

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -15,18 +15,20 @@ import {
   FilledInput,
   InputAdornment,
 } from "@mui/material";
-import { RowType } from "@/_components/features/expenses/type";
-import { Category } from "@/types";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
+import { RowType } from "@/_components/features/expenses/type";
+import { Category } from "@/types";
+import { formatAndUpdateExpense } from "@/_components/features/expenses/expensesServer";
 
 type ExpensesDialogProps = {
   handleClose: () => void;
   open: boolean;
   selectedItem: RowType | null;
   categories: Category[];
+  setRows: React.Dispatch<React.SetStateAction<RowType[]>>;
 };
 
 export const ExpensesDialog: FC<ExpensesDialogProps> = ({
@@ -34,6 +36,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   open,
   selectedItem,
   categories,
+  setRows,
 }) => {
   const dateRef = useRef<HTMLInputElement>(null);
   const storeNameRef = useRef<HTMLInputElement>(null);
@@ -41,18 +44,30 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   const categoryRef = useRef<HTMLInputElement>(null);
 
   const upddateExpenses = () => {
-    const updatedData = {
-      expense_id: selectedItem?.expense_id,
-      date: dateRef.current?.value,
-      storeName: storeNameRef.current?.value,
-      amount: Number(amountRef.current?.value),
-      category_id: categoryRef.current?.value,
-    };
+    if (
+      selectedItem?.expense_id &&
+      dateRef.current?.value &&
+      storeNameRef.current?.value &&
+      amountRef.current?.value &&
+      categoryRef.current?.value
+    ) {
+      try {
+        formatAndUpdateExpense(
+          selectedItem.expense_id,
+          dateRef.current.value,
+          storeNameRef.current.value,
+          Number(amountRef.current.value),
+          Number(categoryRef.current.value)
+        );
+      } catch (error) {
+        // TODO: エラーの対応を考える
+        console.log(error);
+      }
+    } else {
+      // TODO: エラーの対応を考える
+      console.log("The selected values are invalid");
+    }
 
-    // Log the updated data to the console
-    console.log("Updated data:", updatedData);
-
-    // Optionally: Close the dialog after logging
     handleClose();
   };
   return (

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   FormControl,
   Select,
-  SelectChangeEvent,
   InputLabel,
   FilledInput,
   InputAdornment,
@@ -21,10 +20,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import { RowType } from "@/_components/features/expenses/type";
 import { Category } from "@/types";
-import {
-  formatAndUpdateExpense,
-  getAndFormatExpenses,
-} from "@/_components/features/expenses/expensesServer";
+import { formatAndUpdateExpense } from "@/_components/features/expenses/expensesServer";
 
 type ExpensesDialogProps = {
   handleClose: () => void;

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, FC, useEffect, useCallback } from "react";
+import React, { useState, FC, useEffect } from "react";
 import {
   Table,
   TableBody,
@@ -17,7 +17,6 @@ import { ExpensesDialog } from "@/_components/features/expenses";
 import { RowType } from "@/_components/features/expenses/type";
 import { Category } from "@/types";
 import { getAndFormatExpenses } from "@/_components/features/expenses/expensesServer";
-// import { getMonthExpensesWithCategory } from "@/lib/db";
 
 type ExpensesTableProps = {
   userId: string;

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, FC } from "react";
+import React, { useState, FC, useEffect, useCallback } from "react";
 import {
   Table,
   TableBody,
@@ -16,15 +16,37 @@ import { formatCurrency } from "@/utils/financial";
 import { ExpensesDialog } from "@/_components/features/expenses";
 import { RowType } from "@/_components/features/expenses/type";
 import { Category } from "@/types";
+import { getAndFormatExpenses } from "@/_components/features/expenses/expensesServer";
+// import { getMonthExpensesWithCategory } from "@/lib/db";
 
 type ExpensesTableProps = {
-  rows: RowType[];
+  userId: string;
+  firstDay: Date;
+  lastDay: Date;
   categories: Category[];
 };
 
-export const ExpensesTable: FC<ExpensesTableProps> = ({ rows, categories }) => {
+export const ExpensesTable: FC<ExpensesTableProps> = ({
+  userId,
+  firstDay,
+  lastDay,
+  categories,
+}) => {
   const [open, setOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<RowType | null>(null);
+  const [rows, setRows] = useState<RowType[]>([]);
+
+  useEffect(() => {
+    const setFormattedRows = async () => {
+      const formattedExpenses = await getAndFormatExpenses(
+        userId,
+        firstDay,
+        lastDay
+      );
+      setRows(formattedExpenses);
+    };
+    setFormattedRows();
+  }, [userId, firstDay, lastDay]);
 
   // 列がクリックされたときに詳細を表示する関数
   const handleClick = (item: RowType) => {
@@ -85,6 +107,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({ rows, categories }) => {
         open={open}
         selectedItem={selectedItem}
         categories={categories}
+        setRows={setRows}
       />
     </Box>
   );

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -108,6 +108,9 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
         selectedItem={selectedItem}
         categories={categories}
         setRows={setRows}
+        userId={userId}
+        firstDay={firstDay}
+        lastDay={lastDay}
       />
     </Box>
   );

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -36,16 +36,21 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
   const [selectedItem, setSelectedItem] = useState<RowType | null>(null);
   const [rows, setRows] = useState<RowType[]>([]);
 
+  const getExpensesAndSetRows: (
+    userId: string,
+    firstDay: Date,
+    lastDay: Date
+  ) => Promise<void> = async () => {
+    const formattedExpenses = await getAndFormatExpenses(
+      userId,
+      firstDay,
+      lastDay
+    );
+    setRows(formattedExpenses);
+  };
+
   useEffect(() => {
-    const setFormattedRows = async () => {
-      const formattedExpenses = await getAndFormatExpenses(
-        userId,
-        firstDay,
-        lastDay
-      );
-      setRows(formattedExpenses);
-    };
-    setFormattedRows();
+    getExpensesAndSetRows(userId, firstDay, lastDay);
   }, [userId, firstDay, lastDay]);
 
   // 列がクリックされたときに詳細を表示する関数
@@ -107,10 +112,10 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
         open={open}
         selectedItem={selectedItem}
         categories={categories}
-        setRows={setRows}
         userId={userId}
         firstDay={firstDay}
         lastDay={lastDay}
+        getExpensesAndSetRows={getExpensesAndSetRows}
       />
     </Box>
   );

--- a/src/_components/features/expenses/expensesServer.ts
+++ b/src/_components/features/expenses/expensesServer.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { getMonthExpensesWithCategory, updateExpense } from "@/lib/db";
+import { RowType } from "@/_components/features/expenses/type";
+import { formatStrDate } from "@/utils/time";
+
+export const getAndFormatExpenses = async (
+  userId: string,
+  firstDay: Date,
+  lastDay: Date
+): Promise<RowType[]> => {
+  const monthExpensesWithCate = await getMonthExpensesWithCategory(
+    userId,
+    firstDay,
+    lastDay
+  );
+
+  // 出費を特定のフォーマットにする
+  const rows = monthExpensesWithCate.map((expense) => ({
+    expense_id: expense.id,
+    date: expense.date,
+    storeName: expense.storeName,
+    amount: expense.amount,
+    category_id: expense.categoryId,
+    category: expense.category.name,
+  }));
+  return rows;
+};
+
+export const formatAndUpdateExpense = async (
+  expenseId: string,
+  dateStr: string,
+  storeName: string,
+  amount: number,
+  categoryId: number
+) => {
+  const date = formatStrDate(dateStr);
+  if (date === undefined) {
+    throw new Error("The date is invalid");
+  }
+  try {
+    await updateExpense(expenseId, amount, storeName, date, categoryId);
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -1,4 +1,4 @@
-import { getMonthExpensesWithCategory, getCategories } from "@/lib/db";
+import { getCategories } from "@/lib/db";
 import { getToday, getStartAndEndOfMonth } from "@/utils/time";
 import React from "react";
 import { Box } from "@mui/material";
@@ -7,32 +7,21 @@ import { ExpensesTable } from "@/_components/features/expenses";
 export default async function Page() {
   // NOTE: 今後propsもしくは、contextで取得するようにする。
   const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
-  const targetDate = getToday(); // NOTE: 今後変化する指定された日付
+  const targetDate = new Date(2024, 9, 4); // NOTE: 今後変化する指定された日付
 
   // 月の初日と最終日を取得する
   const { firstDay, lastDay } = getStartAndEndOfMonth(targetDate);
 
-  // 月の出費・予算を全て取得する
-  const monthExpensesWithCate = await getMonthExpensesWithCategory(
-    userId,
-    firstDay,
-    lastDay
-  );
-
   const categories = await getCategories();
 
-  // 出費を特定のフォーマットにする
-  const rows = monthExpensesWithCate.map((expense) => ({
-    expense_id: expense.id,
-    date: expense.date,
-    storeName: expense.storeName,
-    amount: expense.amount,
-    category_id: expense.categoryId,
-    category: expense.category.name,
-  }));
   return (
     <Box>
-      <ExpensesTable rows={rows} categories={categories} />
+      <ExpensesTable
+        userId={userId}
+        firstDay={firstDay}
+        lastDay={lastDay}
+        categories={categories}
+      />
     </Box>
   );
 }

--- a/src/lib/db/expense.ts
+++ b/src/lib/db/expense.ts
@@ -2,7 +2,7 @@
 
 import prisma from "@/lib/prisma";
 import { cache } from "react";
-import { Expense, FirstExpenseDate } from "@/types";
+import { Expense, FirstExpenseDate, MonthExpensesWithCategory } from "@/types";
 
 // 指定した月の出費を取得する
 export const getMonthExpenses = cache(
@@ -35,7 +35,11 @@ export const getFirstExpenseDate = cache(
 
 // 指定した月の出費をカテゴリーと共に取得する。
 export const getMonthExpensesWithCategory = cache(
-  async (userId: string, firstDay: Date, lastDay: Date) => {
+  async (
+    userId: string,
+    firstDay: Date,
+    lastDay: Date
+  ): Promise<MonthExpensesWithCategory[]> => {
     return await prisma.expense.findMany({
       where: {
         date: {
@@ -53,3 +57,23 @@ export const getMonthExpensesWithCategory = cache(
     });
   }
 );
+
+export const updateExpense = async (
+  expenseId: string,
+  amount: number,
+  storeName: string,
+  date: Date,
+  categoryId: number
+): Promise<void> => {
+  await prisma.expense.update({
+    where: {
+      id: expenseId,
+    },
+    data: {
+      amount: amount,
+      storeName: storeName,
+      date: date,
+      categoryId: categoryId,
+    },
+  });
+};

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -3,6 +3,7 @@ import {
   getMonthExpenses,
   getFirstExpenseDate,
   getMonthExpensesWithCategory,
+  updateExpense,
 } from "@/lib/db/expense";
 import { getCategories } from "@/lib/db/category";
 
@@ -10,6 +11,7 @@ export {
   getMonthBudgets,
   getMonthExpenses,
   getFirstExpenseDate,
+  updateExpense,
   getCategories,
   getMonthExpensesWithCategory,
 };

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -29,3 +29,19 @@ export const formatDate = (
     day: day ? "numeric" : undefined,
   });
 };
+
+export const formatStrDate = (dateStr: string): Date | undefined => {
+  // 正規表現で年、月、日を抽出
+  const dateParts = dateStr.match(/(\d{4})年(\d{1,2})月(\d{1,2})/);
+
+  // 年、月、日を抽出してDateオブジェクトに変換
+  if (dateParts) {
+    const year = parseInt(dateParts[1], 10);
+    const month = parseInt(dateParts[2], 10) - 1; // 月は0が1月になるので、-1する
+    const day = parseInt(dateParts[3], 10);
+    const newdate = new Date(year, month, day)
+    console.log(newdate);
+    
+    return newdate;
+  }
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -39,9 +39,6 @@ export const formatStrDate = (dateStr: string): Date | undefined => {
     const year = parseInt(dateParts[1], 10);
     const month = parseInt(dateParts[2], 10) - 1; // 月は0が1月になるので、-1する
     const day = parseInt(dateParts[3], 10);
-    const newdate = new Date(year, month, day)
-    console.log(newdate);
-    
-    return newdate;
+    return new Date(year, month, day);
   }
 };


### PR DESCRIPTION
## 概要
出費の詳細ダイアログで変更し、更新を押下すると、更新時に入力されていたデータが一覧に反映されるようにした

## 実装詳細
- まずダイアログで更新ボタンが押された際にその内容をログで出力
  - [✨ ダイアログで更新された出費を取得し、ログで出力するようにした (#74)](https://github.com/AyumuOgasawara/receipt-scanner/commit/2a73fdfa2bf019653a85e4bc472f4fae01b8a2f3)
- prismaを使って、DBの出費のUPDATEをできる関数を実装した
  - [✨ expenseを更新できるようにprismaを使った関数を実装 (#74)](https://github.com/AyumuOgasawara/receipt-scanner/commit/3cafea927ceebad08a73223163f9f2a92827c69a)
- 2024年10月1日 -> Date(2024, 9, 1)になるような関数を実装
  - [✨ "YYYY年MM月DD日"をDateに変換する関数を実装 (#74)](https://github.com/AyumuOgasawara/receipt-scanner/commit/ec0e661ca542d70795b6b0226a4371216aa35788)
- 更新ボタンを押下するとDBのデータが更新されるようにした
  - [✨ 更新ボタンを押すと、データが更新されるように実装した (#74)](https://github.com/AyumuOgasawara/receipt-scanner/pull/79/commits/0b30ce7de1a27b1450567cb440379c62987ec29e) 
- 出費を取得し、出費一覧をsetする関数を更新ボタン押下後に実行するようにした
  - [✨ 更新した出費を反映させるようにした (#74)](https://github.com/AyumuOgasawara/receipt-scanner/pull/79/commits/69b7a56841f8c4157a11d3c4f274b35414d0d7ce)
  - [♻️ ExpenseTableで作成した関数をExpenseDialogに私、データを更新するようにした (#74)](https://github.com/AyumuOgasawara/receipt-scanner/pull/79/commits/235c46506502336f6b7ecc305c03c1642721317a)

## 動作確認

https://github.com/user-attachments/assets/da67f93c-1cf5-4baa-ae8b-669da360161e

## 備考
- 月の最終日を選択すると、一覧に表示されないバグを発見(別イシューで対応する)
