### PR TITLE
✨ 出費詳細ページで削除ボタンを押下し、特定の出費を削除する実装をした(#75)

### DIFF
--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -20,7 +20,10 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import { RowType } from "@/_components/features/expenses/type";
 import { Category } from "@/types";
-import { formatAndUpdateExpense } from "@/_components/features/expenses/expensesServer";
+import {
+  updateSelectedExpense,
+  deleteSelectedExpense,
+} from "@/_components/features/expenses/expensesServer";
 
 type ExpensesDialogProps = {
   handleClose: () => void;
@@ -52,7 +55,8 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   const amountRef = useRef<HTMLInputElement>(null);
   const categoryRef = useRef<HTMLInputElement>(null);
 
-  const upddateExpenses = () => {
+  // 更新ボタンの押下の際に実行する関数
+  const upddateExpenses: () => void = () => {
     if (
       selectedItem?.expense_id &&
       dateRef.current?.value &&
@@ -61,7 +65,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
       categoryRef.current?.value
     ) {
       try {
-        formatAndUpdateExpense(
+        updateSelectedExpense(
           selectedItem.expense_id,
           dateRef.current.value,
           storeNameRef.current.value,
@@ -75,6 +79,26 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
     } else {
       // TODO: エラーの対応を考える
       console.log("The selected values are invalid");
+    }
+
+    // データを再取得し、rowsをセットする
+    getExpensesAndSetRows(userId, firstDay, lastDay);
+
+    handleClose();
+  };
+
+  // 削除ボタンの押下の際に実行する
+  const deleteExpenses: () => void = () => {
+    if (selectedItem?.expense_id) {
+      try {
+        deleteSelectedExpense(selectedItem.expense_id);
+      } catch (error) {
+        // TODO: エラーの対応を考える
+        console.log(error);
+      }
+    } else {
+      // TODO: エラーの対応を考える
+      console.log("Failed to delete the expense");
     }
 
     // データを再取得し、rowsをセットする
@@ -168,7 +192,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
               variant="contained"
               sx={{ fontWeight: "bold" }}
               color="error"
-              onClick={handleClose}
+              onClick={deleteExpenses}
             >
               削除
             </Button>

--- a/src/_components/features/expenses/expensesServer.ts
+++ b/src/_components/features/expenses/expensesServer.ts
@@ -1,6 +1,10 @@
 "use server";
 
-import { getMonthExpensesWithCategory, updateExpense } from "@/lib/db";
+import {
+  getMonthExpensesWithCategory,
+  updateExpense,
+  deleteExpense,
+} from "@/lib/db";
 import { RowType } from "@/_components/features/expenses/type";
 import { formatStrDate } from "@/utils/time";
 
@@ -27,7 +31,8 @@ export const getAndFormatExpenses = async (
   return rows;
 };
 
-export const formatAndUpdateExpense = async (
+// 特定の出費を更新する
+export const updateSelectedExpense = async (
   expenseId: string,
   dateStr: string,
   storeName: string,
@@ -40,6 +45,15 @@ export const formatAndUpdateExpense = async (
   }
   try {
     await updateExpense(expenseId, amount, storeName, date, categoryId);
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 特定の出費を削除する
+export const deleteSelectedExpense = async (expenseId: string) => {
+  try {
+    await deleteExpense(expenseId);
   } catch (error) {
     throw error;
   }

--- a/src/lib/db/expense.ts
+++ b/src/lib/db/expense.ts
@@ -58,6 +58,7 @@ export const getMonthExpensesWithCategory = cache(
   }
 );
 
+// 特定の出費を更新する
 export const updateExpense = async (
   expenseId: string,
   amount: number,
@@ -74,6 +75,15 @@ export const updateExpense = async (
       storeName: storeName,
       date: date,
       categoryId: categoryId,
+    },
+  });
+};
+
+// 特定の出費を削除する
+export const deleteExpense = async (expenseId: string): Promise<void> => {
+  await prisma.expense.delete({
+    where: {
+      id: expenseId,
     },
   });
 };

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -4,6 +4,7 @@ import {
   getFirstExpenseDate,
   getMonthExpensesWithCategory,
   updateExpense,
+  deleteExpense,
 } from "@/lib/db/expense";
 import { getCategories } from "@/lib/db/category";
 
@@ -12,6 +13,7 @@ export {
   getMonthExpenses,
   getFirstExpenseDate,
   updateExpense,
+  deleteExpense,
   getCategories,
   getMonthExpensesWithCategory,
 };


### PR DESCRIPTION
## 概要
- 出費詳細ページで削除ボタンを押下し、特定の出費を削除する実装をした。
- 削除した後に出費一覧を更新した

## 実装詳細
- [✨ 特定の出費をDBから削除する関数の実装 (#75)](https://github.com/AyumuOgasawara/receipt-scanner/commit/f2f5660892096e9bc0d2edb2e875194536f35fd5)
- [✨ 削除ボタンを押下した際に特定のデータを削除し、一覧表示を更新するようにした (#75)](https://github.com/AyumuOgasawara/receipt-scanner/commit/bd0653a99e38475b68925deded033fc657272078)

## 動作確認

https://github.com/user-attachments/assets/241c5872-2084-42dc-b0a4-872b75b74e4b

## 関連タスク
Closes #75 