### PR TITLE
🐛 ダッシュボード下部のy軸のメモリが見切れるバグを修正

### DIFF
--- a/src/_components/common/BarsDataset/BarsDataset.tsx
+++ b/src/_components/common/BarsDataset/BarsDataset.tsx
@@ -2,6 +2,7 @@
 
 import { BarChart } from "@mui/x-charts/BarChart";
 import { axisClasses } from "@mui/x-charts/ChartsAxis";
+import { formatCurrency } from "@/utils/financial";
 import { FC } from "react";
 
 export type BarsDatasetType = {
@@ -35,6 +36,12 @@ export const BarsDataset: FC<BarsDatasetProps> = ({
     <BarChart
       dataset={dataset}
       xAxis={[{ scaleType: "band", dataKey: xAxixsDataKey }]}
+      yAxis={[
+        {
+          valueFormatter: (v) =>
+            v >= 100000 ? `${formatCurrency(v / 10000)}万` : formatCurrency(v),
+        },
+      ]}
       series={series}
       {...chartSetting}
     />

--- a/src/_components/features/dashboard/UpperDashboard.tsx
+++ b/src/_components/features/dashboard/UpperDashboard.tsx
@@ -70,8 +70,11 @@ export const UpperDashboard: FC<UpperDashboardProps> = async ({
   ];
 
   // 日本円の表記にフォーマット
-  const formattedTotalExpensesAmount = formatCurrency(totalExpensesAmount);
-  const formattedTotalBudgetsAmount = formatCurrency(totalBudgetsAmount);
+  const formattedTotalExpensesAmount = formatCurrency(
+    totalExpensesAmount,
+    true
+  );
+  const formattedTotalBudgetsAmount = formatCurrency(totalBudgetsAmount, true);
 
   const daysLeft = remainDaysStr(date.today, date.lastDay);
 

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -98,7 +98,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
                   {formatDate(row.date, { month: true, day: true })}
                 </TableCell>
                 <TableCell>{row.storeName}</TableCell>
-                <TableCell>{formatCurrency(row.amount)}</TableCell>
+                <TableCell>{formatCurrency(row.amount, true)}</TableCell>
                 <TableCell>{row.category}</TableCell>
               </TableRow>
             ))}

--- a/src/utils/financial.ts
+++ b/src/utils/financial.ts
@@ -1,10 +1,13 @@
 import { Budget, Expense } from "@/types";
 
-// 日本円の表記にフォーマット (1000 -> ¥1,000)
-export const formatCurrency = (amount: number): string => {
+// 日本円の表記にフォーマット (useCurrencyがture：1000 -> ¥1,000, useCurrencyがfalse：1000 -> 1,000)
+export const formatCurrency = (
+  amount: number,
+  useCurrency: boolean = false
+): string => {
   return new Intl.NumberFormat("ja-JP", {
-    style: "currency",
-    currency: "JPY",
+    style: useCurrency ? "currency" : "decimal",
+    currency: useCurrency ? "JPY" : undefined,
   }).format(amount);
 };
 


### PR DESCRIPTION
## 概要
ダッシュボード下部のy軸のメモリが見切れるバグを修正を10万以上の金額は表示の仕方を(100,00 -> 10万)に変更した

## 関連タスク
Closes #50 

## 動作確認
10万から、表示の仕方が変わっている
![スクリーンショット 2024-10-10 23 04 05](https://github.com/user-attachments/assets/21dc2585-479e-41f8-8643-2b2f51cc0516)

## 実装詳細
- 表示するメモリが金額のフォーマットになるようにした
  - [✨ 金額のフォーマッターで¥マークをつけるかどうか選べるようにした (#50)](https://github.com/AyumuOgasawara/receipt-scanner/commit/458e046d3ffd1ec84eaec13901c8b85f5fb04ffe)
- 10万以上だと、10万と表示されるようにした
  - [🐛 y軸が見切れるバグを表示方法を10万以上で変更することによって、修正した (#50)](https://github.com/AyumuOgasawara/receipt-scanner/commit/17253e1f0cd83608c230ac2605e9ef5a4ea0c0e9)