### PR TITLE
✨ サイドバーでページが遷移できるようにした (#83)

### DIFF
--- a/src/_components/features/dashboard/UpperDashboard.tsx
+++ b/src/_components/features/dashboard/UpperDashboard.tsx
@@ -80,7 +80,7 @@ export const UpperDashboard: FC<UpperDashboardProps> = async ({
 
   const formattedDate = formatDate(date.targetDate, {
     year: true,
-    month: true,
+    month: "long",
   });
 
   return (

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -95,7 +95,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
                 onClick={() => handleClick(row)}
               >
                 <TableCell>
-                  {formatDate(row.date, { month: true, day: true })}
+                  {formatDate(row.date, { month: "long", day: true })}
                 </TableCell>
                 <TableCell>{row.storeName}</TableCell>
                 <TableCell>{formatCurrency(row.amount, true)}</TableCell>

--- a/src/_components/layouts/Sidebar/Sidebar.tsx
+++ b/src/_components/layouts/Sidebar/Sidebar.tsx
@@ -64,7 +64,7 @@ export const Sidebar = () => {
   const router = useRouter();
   const pathname = usePathname();
 
-  const [selectedPage, setSelectedPage] = useState(
+  const [selectedPage, setSelectedPage] = useState<string>(
     pathname.split("/")[1] || "dashboard"
   );
   const [dateDropdownElements, setDateDropdownElements] = useState<

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -20,12 +20,16 @@ export const getStartAndEndOfMonth = (date: Date): StartAndEndOfMonth => {
 // 2024-10-14T15:00:00.000Z を指定した形に変換する(*何も指定しないと 2024/10/15 がかえる)
 export const formatDate = (
   date: Date,
-  formatOptions: { year?: boolean; month?: boolean; day?: boolean } = {}
+  formatOptions: {
+    year?: boolean;
+    month?: "long" | "2-digit";
+    day?: boolean;
+  } = {}
 ): string => {
   const { year, month, day } = formatOptions;
   return date.toLocaleDateString("ja-JP", {
     year: year ? "numeric" : undefined,
-    month: month ? "long" : undefined,
+    month: month || undefined,
     day: day ? "numeric" : undefined,
   });
 };


### PR DESCRIPTION
## 概要
サイドバーにあるページ遷移のドロップダウンから"dashbord"、"expenses"、"budgets"に遷移できるようにした

## 実装詳細
- onChangeとuseRouterを使用してドロップダウンが変更された際に、変更されたバリューのページに遷移できるようにした。その際にselectedPageが更新され、ドロップダウンのvalueが変更され、見た目が制御されるようにした。
- usePathnameを使用して、現在いるページを取得し、リロードした際にドロップダウンにそのページが再び表示されるようにした
- [✨ dateFormatのmonthを"long"か"2-digit"で選べるようにした (#83)](https://github.com/AyumuOgasawara/receipt-scanner/commit/4b9148c600fad1c7052018c747d4546f7e89ac7c)
- [✨ サイドバーでページ遷移ができるようにした (#83)](https://github.com/AyumuOgasawara/receipt-scanner/commit/80c36b5c541029f1641a86f8f2d7c7f13d2d1a9c)

## 動作確認

https://github.com/user-attachments/assets/0b145642-43e5-45c2-8060-b8f6badd6528

