### PR TITLE
✨ サイドバーから月を指定できるようにした (#64)

### DIFF
--- a/src/_components/features/sidebar/Sidebar.tsx
+++ b/src/_components/features/sidebar/Sidebar.tsx
@@ -43,7 +43,7 @@ export const Sidebar: FC<SidebarProps> = ({
   const handlePageChange = (event: any) => {
     const selectedPage = event.target.value;
     setSelectedPage(selectedPage);
-    router.push(`/${selectedPage}`); // 選択されたページに遷移
+    router.push(`/${selectedPage}` + "?date=" + selectedDate); // 選択されたページに遷移
   };
 
   const handleDateChange = (event: any) => {

--- a/src/_components/features/sidebar/type.ts
+++ b/src/_components/features/sidebar/type.ts
@@ -1,0 +1,4 @@
+export type dateDropdownElement = {
+  dateValue: string;
+  dateView: string;
+};

--- a/src/_components/features/sidebar/yearMonthElements.ts
+++ b/src/_components/features/sidebar/yearMonthElements.ts
@@ -1,0 +1,44 @@
+import { dateDropdownElement } from "@/_components/features/sidebar/type";
+import { formatDate } from "@/utils/time";
+
+// 最初の月から今日までの年月をリストにする
+export const getDatesInRange = (
+  firstExpenseDate: Date,
+  today: Date
+): Date[] => {
+  const monthsInRange: Date[] = [];
+
+  if (firstExpenseDate) {
+    // minDateの年月を取得
+    let currentDate = new Date(
+      firstExpenseDate.getFullYear(),
+      firstExpenseDate.getMonth(),
+      1
+    );
+
+    while (currentDate <= today) {
+      // 年と月を取得し、Data型でその年月の15日を保存
+      const year = currentDate.getFullYear();
+      const month = currentDate.getMonth();
+      monthsInRange.push(new Date(year, month, 15)); // UTCでわかりづらいため、15日にし、年月は分かりやすいようにした
+
+      // 次の月に移動
+      currentDate.setMonth(currentDate.getMonth() + 1);
+    }
+  }
+  return monthsInRange;
+};
+
+export const makeDateElements = (
+  datesInRange: Date[]
+): dateDropdownElement[] => {
+  return datesInRange.map((date): dateDropdownElement => {
+    return {
+      dateValue: formatDate(date, { year: true, month: "2-digit" }).replace(
+        "/",
+        "-"
+      ),
+      dateView: formatDate(date, { year: true, month: "long" }),
+    };
+  });
+};

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,8 +8,18 @@ import { calculateTotalAmount, categoryTotals } from "@/utils/financial";
 import { BarsDatasetType } from "@/_components/common/BarsDataset/BarsDataset";
 import { Box } from "@mui/material";
 import { Sidebar } from "@/_components/features/sidebar/Sidebar";
+import {
+  getDatesInRange,
+  makeDateElements,
+} from "@/_components/features/sidebar/yearMonthElements";
 
-export default async function Page() {
+import { getFirstExpenseDate } from "@/lib/db/index";
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | undefined };
+}) {
   const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
   const today = getToday(); // 本日の時間を取得 UTC時間
   const targetDate = today; // NOTE: 今後変化する指定された日付
@@ -47,6 +57,23 @@ export default async function Page() {
     lastDay: lastDay,
   };
 
+  // 初めての出費日を取得
+  const firstExpense = await getFirstExpenseDate(userId);
+
+  // 初めの出費日を定義
+  const firstExpenseDate = firstExpense._min.date ?? today;
+
+  // 初めての出費から今日までの月日をリストで取得し、サイドバーの月日ドロップダウンに渡す型に整形
+  const datesInRange = getDatesInRange(firstExpenseDate, today);
+  const dateDropdown = makeDateElements(datesInRange);
+
+  // クエリからdateを取得
+  const paramDate =
+    searchParams["date"] ??
+    `${today.getFullYear()}-${(today.getMonth() + 1)
+      .toString()
+      .padStart(2, "0")}`;
+
   return (
     <Box display="flex" flexDirection="row" height="100%">
       <Box
@@ -65,7 +92,7 @@ export default async function Page() {
         {/* NOTE: Lowerのサイズを動的にしたい */}
         <LowerDashboard dataset={dataset} />
       </Box>
-      <Sidebar />
+      <Sidebar paramDate={paramDate} dateDropdownElements={dateDropdown} />
     </Box>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -22,7 +22,18 @@ export default async function Page({
 }) {
   const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
   const today = getToday(); // 本日の時間を取得 UTC時間
-  const targetDate = today; // NOTE: 今後変化する指定された日付
+
+  // クエリからdateを取得
+  const paramDate =
+    searchParams["date"] ??
+    `${today.getFullYear()}-${(today.getMonth() + 1)
+      .toString()
+      .padStart(2, "0")}`;
+
+  // 年と月を取得
+  const [year, month] = paramDate.split("-").map(Number);
+
+  const targetDate = new Date(year, month - 1); // NOTE: 今後変化する指定された日付
 
   // 月の初日と最終日を取得する
   const { firstDay, lastDay } = getStartAndEndOfMonth(targetDate);
@@ -66,13 +77,6 @@ export default async function Page({
   // 初めての出費から今日までの月日をリストで取得し、サイドバーの月日ドロップダウンに渡す型に整形
   const datesInRange = getDatesInRange(firstExpenseDate, today);
   const dateDropdown = makeDateElements(datesInRange);
-
-  // クエリからdateを取得
-  const paramDate =
-    searchParams["date"] ??
-    `${today.getFullYear()}-${(today.getMonth() + 1)
-      .toString()
-      .padStart(2, "0")}`;
 
   return (
     <Box display="flex" flexDirection="row" height="100%">

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -1,19 +1,46 @@
 import { getCategories } from "@/lib/db";
 import { getToday, getStartAndEndOfMonth } from "@/utils/time";
+import {
+  getDatesInRange,
+  makeDateElements,
+} from "@/_components/features/sidebar/yearMonthElements";
 import React from "react";
 import { Box } from "@mui/material";
 import { ExpensesTable } from "@/_components/features/expenses";
 import { Sidebar } from "@/_components/features/sidebar/Sidebar";
+import { getFirstExpenseDate } from "@/lib/db/index";
 
-export default async function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | undefined };
+}) {
   // NOTE: 今後propsもしくは、contextで取得するようにする。
   const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
+  const today = getToday();
   const targetDate = new Date(2024, 9, 4); // NOTE: 今後変化する指定された日付
 
   // 月の初日と最終日を取得する
   const { firstDay, lastDay } = getStartAndEndOfMonth(targetDate);
 
   const categories = await getCategories();
+
+  // 初めての出費日を取得
+  const firstExpense = await getFirstExpenseDate(userId);
+
+  // 初めの出費日を定義
+  const firstExpenseDate = firstExpense._min.date ?? today;
+
+  // 初めての出費から今日までの月日をリストで取得し、サイドバーの月日ドロップダウンに渡す型に整形
+  const datesInRange = getDatesInRange(firstExpenseDate, today);
+  const dateDropdown = makeDateElements(datesInRange);
+
+  // クエリからdateを取得
+  const paramDate =
+    searchParams["date"] ??
+    `${today.getFullYear()}-${(today.getMonth() + 1)
+      .toString()
+      .padStart(2, "0")}`;
 
   return (
     <Box display="flex" flexDirection="row" height="100%">
@@ -32,7 +59,7 @@ export default async function Page() {
           categories={categories}
         />
       </Box>
-      <Sidebar />
+      <Sidebar paramDate={paramDate} dateDropdownElements={dateDropdown} />
     </Box>
   );
 }

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -18,7 +18,18 @@ export default async function Page({
   // NOTE: 今後propsもしくは、contextで取得するようにする。
   const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
   const today = getToday();
-  const targetDate = new Date(2024, 9, 4); // NOTE: 今後変化する指定された日付
+
+  // クエリからdateを取得
+  const paramDate =
+    searchParams["date"] ??
+    `${today.getFullYear()}-${(today.getMonth() + 1)
+      .toString()
+      .padStart(2, "0")}`;
+
+  // 年と月を取得
+  const [year, month] = paramDate.split("-").map(Number);
+
+  const targetDate = new Date(year, month - 1);
 
   // 月の初日と最終日を取得する
   const { firstDay, lastDay } = getStartAndEndOfMonth(targetDate);
@@ -34,13 +45,6 @@ export default async function Page({
   // 初めての出費から今日までの月日をリストで取得し、サイドバーの月日ドロップダウンに渡す型に整形
   const datesInRange = getDatesInRange(firstExpenseDate, today);
   const dateDropdown = makeDateElements(datesInRange);
-
-  // クエリからdateを取得
-  const paramDate =
-    searchParams["date"] ??
-    `${today.getFullYear()}-${(today.getMonth() + 1)
-      .toString()
-      .padStart(2, "0")}`;
 
   return (
     <Box display="flex" flexDirection="row" height="100%">


### PR DESCRIPTION
## 概要
サイドバーの年月を指定するドロップダウンを選択すると、dateクエリがセットされ、そのdateクエリを各ページで取得して、月毎のデータが一覧できるようにした

## 動作確認

https://github.com/user-attachments/assets/90e80033-9b3e-46d5-a4f6-f7b164b385cf

## 実装詳細
- 年月ドロップダウンの要素やdateのクエリを親コンポーネントである、各ページから取得するようにし、年月ドロップダウンが変わると、dateクエリがセットされるようにした
  - [✨ サイドバーで日付を選択すると、クエリにdateがセットされるようにしたし、リロードしするとセットされているクエリをバリューにもつ年月がドロップダウンに入るようにした(#64)](https://github.com/AyumuOgasawara/receipt-scanner/commit/3e5de2ea10de3534b1a4d5613ff37cc8a7f719ae)
- ページの切り替えドロップダウンでも、dateクエリを一緒にpushするようにした
  - [✨ ページの切り替えの際にdateクエリも一緒にpushするようにした (#64)](https://github.com/AyumuOgasawara/receipt-scanner/commit/77de9e745d9e53a571ee0b8e01a4201841b7e281)
- 各ページコンポーネントから子コンポーネントに送るtargetDateをクエリのdateと一緒に動的に変化するようにした
  - [✨ 各ページのtargetDateをクエリから取得したdateと同じになるようにした (#64)](https://github.com/AyumuOgasawara/receipt-scanner/commit/2a0129647eb4a2036fec167280640479490abf8f)

## 関連タスク
Closes #64 