### PR TITLE
🗃️ DBのレシートテーブルを更新した (#103)

### DIFF
--- a/prisma/migrations/20241020035142_initial_schema/migration.sql
+++ b/prisma/migrations/20241020035142_initial_schema/migration.sql
@@ -35,7 +35,7 @@ CREATE TABLE "categories" (
 -- CreateTable
 CREATE TABLE "receipts" (
     "id" UUID NOT NULL,
-    "file_path" TEXT NOT NULL,
+    "file_name" TEXT NOT NULL,
     "expense_id" UUID NOT NULL,
 
     CONSTRAINT "receipts_pkey" PRIMARY KEY ("id")
@@ -61,6 +61,9 @@ CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
 CREATE UNIQUE INDEX "categories_name_key" ON "categories"("name");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "receipts_file_name_key" ON "receipts"("file_name");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "receipts_expense_id_key" ON "receipts"("expense_id");
 
 -- AddForeignKey
@@ -70,7 +73,7 @@ ALTER TABLE "expenses" ADD CONSTRAINT "expenses_user_id_fkey" FOREIGN KEY ("user
 ALTER TABLE "expenses" ADD CONSTRAINT "expenses_category_id_fkey" FOREIGN KEY ("category_id") REFERENCES "categories"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "receipts" ADD CONSTRAINT "receipts_expense_id_fkey" FOREIGN KEY ("expense_id") REFERENCES "expenses"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "receipts" ADD CONSTRAINT "receipts_expense_id_fkey" FOREIGN KEY ("expense_id") REFERENCES "expenses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "budgets" ADD CONSTRAINT "budgets_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,7 +59,7 @@ model Receipt {
   fileName String @map("file_name") @unique
   expenseId String @unique @map("expense_id") @db.Uuid
 
-  expense Expense @relation(fields: [expenseId], references: [id])
+  expense Expense @relation(fields: [expenseId], references: [id], onDelete: Cascade)
 
   @@map("receipts")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,8 +56,7 @@ model Category {
 
 model Receipt {
   id       String @id @default(uuid()) @db.Uuid
-  filePath String @map("file_path")
-
+  fileName String @map("file_name") @unique
   expenseId String @unique @map("expense_id") @db.Uuid
 
   expense Expense @relation(fields: [expenseId], references: [id])

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -78,7 +78,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
       }
     } else {
       // TODO: エラーの対応を考える
-      console.log("The selected values are invalid");
+      console.log("Failed to update the expense");
     }
 
     // データを再取得し、rowsをセットする

--- a/src/app/budgets/page.tsx
+++ b/src/app/budgets/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({
   searchParams: { [key: string]: string | undefined };
 }) {
   // NOTE: 今後propsもしくは、contextで取得するようにする。
-  const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
+  const userId = "1672b84c-43ec-4e96-aad2-125410361991";
   const today = getToday();
   const todayYear = today.getFullYear();
   const todayMonth = today.getMonth();

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -20,7 +20,7 @@ export default async function Page({
 }: {
   searchParams: { [key: string]: string | undefined };
 }) {
-  const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
+  const userId = "1672b84c-43ec-4e96-aad2-125410361991";
   const today = getToday(); // 本日の時間を取得 UTC時間
 
   // クエリからdateを取得

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({
   searchParams: { [key: string]: string | undefined };
 }) {
   // NOTE: 今後propsもしくは、contextで取得するようにする。
-  const userId = "8f412478-c428-4399-b934-9f0d0cf0a6c5";
+  const userId = "1672b84c-43ec-4e96-aad2-125410361991";
   const today = getToday();
 
   // クエリからdateを取得

--- a/src/lib/db/expense.ts
+++ b/src/lib/db/expense.ts
@@ -107,7 +107,7 @@ export const createExpense = async (
       receipt: fileName
         ? {
             create: {
-              filePath: fileName,
+              fileName: fileName,
             },
           }
         : undefined,


### PR DESCRIPTION
## 概要
- [🗃️ filePath -> filrNameに変更し、ユニークではなくてはならないようにした (#103)](https://github.com/AyumuOgasawara/receipt-scanner/commit/1c4395b3bc629820ad52301e92784216b7443027)
- onDelete: Cascadeをつけて、出費削除時にレシートも削除されるようにした
  - [🗃️　レシートを出費と共に削除できるようにしいた (#103)](https://github.com/AyumuOgasawara/receipt-scanner/commit/3ca0f6e2fbb0090f96ce59768bf9858c2cd9a472)
- また、同じレシートを更新すると、更新できないエラーメッセージが出るようにした。
  - [💡 エラーメッセージを変更した (#103)](https://github.com/AyumuOgasawara/receipt-scanner/commit/f249bfe30475ecc4f3943fd1133f4ea52bacd57d)


## 動作確認
レシートが入っているデータベースに対して、削除ができるようになった。
https://github.com/user-attachments/assets/d1fa6adc-a58e-4d9e-8864-85be541cf42e

現在は出費から同じレシートを入れるとエラーが出るようになっている。別イシューで対応。
<img width="1425" alt="スクリーンショット 2024-10-20 13 28 34" src="https://github.com/user-attachments/assets/0373cc2a-b8d7-463c-a2cb-fd944817109d">





