### PR TITLE
✨ generateGetPreSignedURLを作成し、画像データをs3から取得できるpre signed urlを発行できるようにした (#106)

### DIFF
--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -71,7 +71,6 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
 
   const handleCreateExpense = () => {
     if (expenseDate && storeName && amount && categoryId) {
-      console.log(expenseDate, storeName, amount, categoryId, fileName);
       formatAndCreateExpense(
         userId,
         expenseDate,

--- a/src/_components/features/sidebar/Sidebar.tsx
+++ b/src/_components/features/sidebar/Sidebar.tsx
@@ -51,7 +51,7 @@ export const Sidebar: FC<SidebarProps> = ({
   const [selectedDate, setSelectedDate] = useState<string>(paramDate);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
-  const [expenseDate, setExpenseDate] = useState<Date | undefined>(undefined);
+  const [expenseDate, setExpenseDate] = useState<Date>(today);
   const [storeName, setStoreName] = useState<string>("");
   const [amount, setAmount] = useState<number>(0);
   const [categoryId, setCategoryId] = useState<number>(1);
@@ -92,7 +92,7 @@ export const Sidebar: FC<SidebarProps> = ({
     setOpen(false);
     setSelectedImage(null);
     setFileName(null);
-    setExpenseDate(undefined);
+    setExpenseDate(today);
     setStoreName("");
     setAmount(0);
     setCategoryId(1);

--- a/src/_components/features/sidebar/SidebarServer.ts
+++ b/src/_components/features/sidebar/SidebarServer.ts
@@ -7,8 +7,7 @@ import { createExpense } from "@/lib/db";
 import {
   uploadFileToS3,
   downloadFileFromS3,
-  generatePutPreSignedURL,
-  generateGetPreSignedURL,
+  generatePreSignedURL,
 } from "@/lib/s3";
 
 // 最初の月から今日までの年月をリストにする
@@ -57,9 +56,9 @@ export const getReceiptDetail = async (
   selectedImage: string,
   fileName: string
 ): Promise<ReceiptDetail> => {
-  const putPreSignedURL = await generatePutPreSignedURL(fileName);
+  const putPreSignedURL = await generatePreSignedURL(fileName, "put");
   uploadFileToS3(selectedImage, putPreSignedURL);
-  const getPreSignedURL = await generateGetPreSignedURL(fileName);
+  const getPreSignedURL = await generatePreSignedURL(fileName, "get");
   const downloadImg = downloadFileFromS3(getPreSignedURL);
   // NOTE: 一旦以下を返す。
   return {

--- a/src/_components/features/sidebar/SidebarServer.ts
+++ b/src/_components/features/sidebar/SidebarServer.ts
@@ -4,7 +4,12 @@ import {
 } from "@/_components/features/sidebar/type";
 import { formatDate } from "@/utils/time";
 import { createExpense } from "@/lib/db";
-import { uploadFileToS3, generatePutPreSignedURL } from "@/lib/s3";
+import {
+  uploadFileToS3,
+  downloadFileFromS3,
+  generatePutPreSignedURL,
+  generateGetPreSignedURL,
+} from "@/lib/s3";
 
 // 最初の月から今日までの年月をリストにする
 export const getDatesInRange = (
@@ -54,6 +59,8 @@ export const getReceiptDetail = async (
 ): Promise<ReceiptDetail> => {
   const putPreSignedURL = await generatePutPreSignedURL(fileName);
   uploadFileToS3(selectedImage, putPreSignedURL);
+  const getPreSignedURL = await generateGetPreSignedURL(fileName);
+  const downloadImg = downloadFileFromS3(getPreSignedURL);
   // NOTE: 一旦以下を返す。
   return {
     storeName: "八百屋",

--- a/src/_components/features/sidebar/type.ts
+++ b/src/_components/features/sidebar/type.ts
@@ -11,8 +11,8 @@ export type ReceiptDetail = {
 };
 
 export type ExpenseDetail = {
-  expenseDate: Date | undefined;
-  setExpenseDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
+  expenseDate: Date;
+  setExpenseDate: React.Dispatch<React.SetStateAction<Date>>;
   storeName: string;
   setStoreName: React.Dispatch<React.SetStateAction<string>>;
   amount: number;

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -1,6 +1,10 @@
 "use server";
 
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 const REGION = "ap-northeast-1";
@@ -15,7 +19,9 @@ const s3 = new S3Client({
   },
 });
 
-export const generatePutPreSignedURL = async (fileName: string) => {
+export const generatePutPreSignedURL = async (
+  fileName: string
+): Promise<string> => {
   const params = {
     Bucket: BUCKET_NAME,
     Key: fileName,
@@ -31,7 +37,7 @@ export const generatePutPreSignedURL = async (fileName: string) => {
 export const uploadFileToS3 = async (
   fileData: string, // base64エンコードされた画像データ
   putPreSignedURL: string
-) => {
+): Promise<void> => {
   // base64の文字列からbase64部分を取り出し、デコード
   const byteString = atob(fileData.split(",")[1]);
 
@@ -60,4 +66,23 @@ export const uploadFileToS3 = async (
   if (!response.ok) {
     throw new Error("S3へのアップロードに失敗しました");
   }
+};
+
+export const generateGetPreSignedURL = async (
+  fileName: string
+): Promise<string> => {
+  const params = {
+    Bucket: BUCKET_NAME,
+    Key: fileName,
+  };
+
+  const command = new GetObjectCommand(params);
+
+  // Pre-signed URLを生成
+  const getPreSignedURL = await getSignedUrl(s3, command, { expiresIn: 300 });
+  return getPreSignedURL;
+};
+
+export const downloadFileFromS3 = (downloadrePreSignedURL: string) => {
+  return "imag_data";
 };


### PR DESCRIPTION
## 概要
- 初めにカレンダーの初期値がundefinedだが、UI上では本日の日付が入っていたため、混乱を招かぬように、初期値を本日の日付にした
- PythonとNextの出費詳細でレシート画像が見れるようにGetPreSignedURLを発行した。

## 詳細
- GetObjectCommandを使用してGetPreSignedURLを発行した
- putとgetの場合のpreSignedURLの発行の仕方が似ていたため、一つにまとめた。」

## 動作確認
- 解析を押下すると画像がアップロードされたため、デグレなし
- getPreSighnedURlを確認することができた。

## 関連タスク
Closes #106 