### PR TITLE
✨ 出費詳細ページでレシートを表示されるようにした (#108)

### DIFF
--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -25,6 +25,7 @@ import {
   deleteSelectedExpense,
   downloadReceiptImage,
 } from "@/_components/features/expenses/ExpensesServer";
+import { ShowReceipt } from "@/_components/features/expenses";
 
 type ExpensesDialogProps = {
   handleClose: () => void;
@@ -121,106 +122,100 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
     handleClose();
   };
   return (
-    <>
-      <Box sx={{ position: "relative" }}>
-        <Dialog
-          open={open}
-          onClose={handleClose}
-          sx={{
-            "& .MuiDialog-paper": {
-              right: "10%",
-            },
-          }}
-        >
-          <DialogContent>
-            {selectedItem && (
-              <Box
-                display="flex"
-                flexDirection="column"
-                component="form"
-                sx={{ "& .MuiTextField-root": { m: 1 } }}
-              >
-                {/* TODO: 全ての要素がrequiredでなければならない */}
-                <LocalizationProvider dateAdapter={AdapterDayjs}>
-                  <DemoContainer components={["DatePicker"]}>
-                    <DatePicker
-                      defaultValue={dayjs(selectedItem.date)}
-                      label="日付"
-                      slotProps={{
-                        calendarHeader: {
-                          format: "YYYY年MM月", // カレンダーの年月の部分
-                        },
-                        textField: {
-                          variant: "filled",
-                        },
-                      }}
-                      format="YYYY年MM月DD" // 入力欄
-                      inputRef={dateRef}
-                    />
-                  </DemoContainer>
-                </LocalizationProvider>
-                <TextField
-                  id="store-name"
-                  label="店名"
-                  defaultValue={selectedItem.storeName}
-                  variant="filled"
-                  inputRef={storeNameRef}
-                />
-                <FormControl sx={{ m: 1, minWidth: 120 }} variant="filled">
-                  <InputLabel id="amount">金額</InputLabel>
-                  <FilledInput
-                    startAdornment={
-                      <InputAdornment position="start">¥</InputAdornment>
-                    }
-                    type="number"
-                    defaultValue={selectedItem.amount}
-                    inputRef={amountRef}
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      sx={{
+        "& .MuiDialog-paper": {
+          right: "10%",
+          width: "50%",
+          height: "70%",
+        },
+      }}
+    >
+      <DialogContent>
+        <Box display="flex" flexDirection="row" height={"100%"}>
+          <ShowReceipt receiptImage={receiptImage} />
+          {selectedItem && (
+            <Box
+              display="flex"
+              flexDirection="column"
+              component="form"
+              sx={{ "& .MuiTextField-root": { m: 1 } }}
+            >
+              {/* TODO: 全ての要素がrequiredでなければならない */}
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DemoContainer components={["DatePicker"]}>
+                  <DatePicker
+                    defaultValue={dayjs(selectedItem.date)}
+                    label="日付"
+                    slotProps={{
+                      calendarHeader: {
+                        format: "YYYY年MM月", // カレンダーの年月の部分
+                      },
+                      textField: {
+                        variant: "filled",
+                      },
+                    }}
+                    format="YYYY年MM月DD" // 入力欄
+                    inputRef={dateRef}
                   />
-                </FormControl>
-                <FormControl sx={{ m: 1, minWidth: 120 }}>
-                  <InputLabel variant="filled">カテゴリー</InputLabel>
-                  <Select
-                    native
-                    variant="filled"
-                    defaultValue={selectedItem.categoryId}
-                    inputRef={categoryRef}
-                  >
-                    {categories.map((category) => (
-                      <option key={category.id} value={category.id}>
-                        {category.name}
-                      </option>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
-            )}
-          </DialogContent>
-          <DialogActions>
-            <Button
-              variant="contained"
-              sx={{ fontWeight: "bold", marginRight: "64px" }}
-              onClick={handleClose}
-            >
-              レシートを表示
-            </Button>
-            <Button
-              variant="contained"
-              sx={{ fontWeight: "bold" }}
-              color="error"
-              onClick={deleteExpenses}
-            >
-              削除
-            </Button>
-            <Button
-              variant="contained"
-              sx={{ fontWeight: "bold" }}
-              onClick={upddateExpenses}
-            >
-              更新
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </Box>
-    </>
+                </DemoContainer>
+              </LocalizationProvider>
+              <TextField
+                id="store-name"
+                label="店名"
+                defaultValue={selectedItem.storeName}
+                variant="filled"
+                inputRef={storeNameRef}
+              />
+              <FormControl sx={{ m: 1, minWidth: 120 }} variant="filled">
+                <InputLabel id="amount">金額</InputLabel>
+                <FilledInput
+                  startAdornment={
+                    <InputAdornment position="start">¥</InputAdornment>
+                  }
+                  type="number"
+                  defaultValue={selectedItem.amount}
+                  inputRef={amountRef}
+                />
+              </FormControl>
+              <FormControl sx={{ m: 1, minWidth: 120 }}>
+                <InputLabel variant="filled">カテゴリー</InputLabel>
+                <Select
+                  native
+                  variant="filled"
+                  defaultValue={selectedItem.categoryId}
+                  inputRef={categoryRef}
+                >
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="contained"
+          sx={{ fontWeight: "bold" }}
+          color="error"
+          onClick={deleteExpenses}
+        >
+          削除
+        </Button>
+        <Button
+          variant="contained"
+          sx={{ fontWeight: "bold" }}
+          onClick={upddateExpenses}
+        >
+          更新
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 };

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC, useRef } from "react";
+import React, { FC, useEffect, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -23,6 +23,7 @@ import { Category } from "@/types";
 import {
   updateSelectedExpense,
   deleteSelectedExpense,
+  downloadReceiptImage,
 } from "@/_components/features/expenses/ExpensesServer";
 
 type ExpensesDialogProps = {
@@ -54,11 +55,24 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   const storeNameRef = useRef<HTMLInputElement>(null);
   const amountRef = useRef<HTMLInputElement>(null);
   const categoryRef = useRef<HTMLInputElement>(null);
+  const fileName = selectedItem?.fileName;
+  const [receiptImage, setReceiptImage] = useState<string | null>(null);
+
+  const getReceiptImage = async (): Promise<void> => {
+    if (fileName) {
+      const downloadImg = await downloadReceiptImage(fileName);
+      setReceiptImage(downloadImg);
+    }
+  };
+
+  useEffect(() => {
+    getReceiptImage();
+  }, [fileName !== undefined]);
 
   // 更新ボタンの押下の際に実行する関数
   const upddateExpenses: () => void = () => {
     if (
-      selectedItem?.expense_id &&
+      selectedItem?.expenseId &&
       dateRef.current?.value &&
       storeNameRef.current?.value &&
       amountRef.current?.value &&
@@ -66,7 +80,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
     ) {
       try {
         updateSelectedExpense(
-          selectedItem.expense_id,
+          selectedItem.expenseId,
           dateRef.current.value,
           storeNameRef.current.value,
           Number(amountRef.current.value),
@@ -89,9 +103,9 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
 
   // 削除ボタンの押下の際に実行する
   const deleteExpenses: () => void = () => {
-    if (selectedItem?.expense_id) {
+    if (selectedItem?.expenseId) {
       try {
-        deleteSelectedExpense(selectedItem.expense_id);
+        deleteSelectedExpense(selectedItem.expenseId);
       } catch (error) {
         // TODO: エラーの対応を考える
         console.log(error);
@@ -168,7 +182,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
                   <Select
                     native
                     variant="filled"
-                    defaultValue={selectedItem.category_id}
+                    defaultValue={selectedItem.categoryId}
                     inputRef={categoryRef}
                   >
                     {categories.map((category) => (

--- a/src/_components/features/expenses/ExpenseDialog.tsx
+++ b/src/_components/features/expenses/ExpenseDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC, useEffect, useRef, useState } from "react";
+import React, { FC, useEffect, useRef} from "react";
 import {
   Dialog,
   DialogContent,
@@ -23,7 +23,7 @@ import { Category } from "@/types";
 import {
   updateSelectedExpense,
   deleteSelectedExpense,
-  downloadReceiptImage,
+  getPreSignedURL,
 } from "@/_components/features/expenses/ExpensesServer";
 import { ShowReceipt } from "@/_components/features/expenses";
 
@@ -35,6 +35,8 @@ type ExpensesDialogProps = {
   userId: string;
   firstDay: Date;
   lastDay: Date;
+  receiptImage: string | null;
+  setReceiptImage: React.Dispatch<React.SetStateAction<string | null>>;
   getExpensesAndSetRows: (
     userId: string,
     firstDay: Date,
@@ -50,6 +52,8 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   userId,
   firstDay,
   lastDay,
+  receiptImage,
+  setReceiptImage,
   getExpensesAndSetRows,
 }) => {
   const dateRef = useRef<HTMLInputElement>(null);
@@ -57,11 +61,10 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
   const amountRef = useRef<HTMLInputElement>(null);
   const categoryRef = useRef<HTMLInputElement>(null);
   const fileName = selectedItem?.fileName;
-  const [receiptImage, setReceiptImage] = useState<string | null>(null);
 
   const getReceiptImage = async (): Promise<void> => {
     if (fileName) {
-      const downloadImg = await downloadReceiptImage(fileName);
+      const downloadImg = await getPreSignedURL(fileName);
       setReceiptImage(downloadImg);
     }
   };
@@ -135,7 +138,7 @@ export const ExpensesDialog: FC<ExpensesDialogProps> = ({
     >
       <DialogContent>
         <Box display="flex" flexDirection="row" height={"100%"}>
-          <ShowReceipt receiptImage={receiptImage} />
+          <ShowReceipt receiptImage={receiptImage} fileName={fileName} />
           {selectedItem && (
             <Box
               display="flex"

--- a/src/_components/features/expenses/ExpensesServer.ts
+++ b/src/_components/features/expenses/ExpensesServer.ts
@@ -7,26 +7,28 @@ import {
 } from "@/lib/db";
 import { RowType } from "@/_components/features/expenses/type";
 import { formatStrDate } from "@/utils/time";
+import { downloadFileFromS3, generatePreSignedURL } from "@/lib/s3";
 
 export const getAndFormatExpenses = async (
   userId: string,
   firstDay: Date,
   lastDay: Date
 ): Promise<RowType[]> => {
-  const monthExpensesWithCate = await getMonthExpensesWithCategory(
+  const monthExpensesWithCateReceipt = await getMonthExpensesWithCategory(
     userId,
     firstDay,
     lastDay
   );
 
   // 出費を特定のフォーマットにする
-  const rows = monthExpensesWithCate.map((expense) => ({
-    expense_id: expense.id,
+  const rows = monthExpensesWithCateReceipt.map((expense) => ({
+    expenseId: expense.id,
     date: expense.date,
     storeName: expense.storeName,
     amount: expense.amount,
-    category_id: expense.categoryId,
+    categoryId: expense.categoryId,
     category: expense.category.name,
+    fileName: expense.receipt?.fileName,
   }));
   return rows;
 };
@@ -57,4 +59,12 @@ export const deleteSelectedExpense = async (expenseId: string) => {
   } catch (error) {
     throw error;
   }
+};
+
+export const downloadReceiptImage = async (fileName: string) => {
+  const getPreSignedURL = await generatePreSignedURL(fileName, "get");
+  console.log(getPreSignedURL);
+
+  const downloadImg = await downloadFileFromS3(getPreSignedURL);
+  return downloadImg;
 };

--- a/src/_components/features/expenses/ExpensesServer.ts
+++ b/src/_components/features/expenses/ExpensesServer.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/db";
 import { RowType } from "@/_components/features/expenses/type";
 import { formatStrDate } from "@/utils/time";
-import { downloadFileFromS3, generatePreSignedURL } from "@/lib/s3";
+import { generatePreSignedURL } from "@/lib/s3";
 
 export const getAndFormatExpenses = async (
   userId: string,
@@ -61,10 +61,7 @@ export const deleteSelectedExpense = async (expenseId: string) => {
   }
 };
 
-export const downloadReceiptImage = async (fileName: string) => {
-  const getPreSignedURL = await generatePreSignedURL(fileName, "get");
-  console.log(getPreSignedURL);
-
-  const downloadImg = await downloadFileFromS3(getPreSignedURL);
-  return downloadImg;
+export const getPreSignedURL = async (fileName: string) => {
+  const preSignedURL = await generatePreSignedURL(fileName, "get");
+  return preSignedURL;
 };

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -89,7 +89,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
           <TableBody>
             {rows.map((row) => (
               <TableRow
-                key={row.expense_id}
+                key={row.expenseId}
                 hover
                 style={{ cursor: "pointer" }}
                 onClick={() => handleClick(row)}

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -34,6 +34,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
   const [open, setOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<RowType | null>(null);
   const [rows, setRows] = useState<RowType[]>([]);
+  const [receiptImage, setReceiptImage] = useState<string | null>(null);
 
   const getExpensesAndSetRows: (
     userId: string,
@@ -62,6 +63,7 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
   const handleClose = () => {
     setOpen(false);
     setSelectedItem(null);
+    setReceiptImage(null);
   };
 
   const headers = ["日付", "店名", "金額", "カテゴリー"];
@@ -115,6 +117,8 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
         firstDay={firstDay}
         lastDay={lastDay}
         getExpensesAndSetRows={getExpensesAndSetRows}
+        receiptImage={receiptImage}
+        setReceiptImage={setReceiptImage}
       />
     </Box>
   );

--- a/src/_components/features/expenses/ShowReceipt.tsx
+++ b/src/_components/features/expenses/ShowReceipt.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from "react";
+import { Box, Avatar } from "@mui/material";
+
+type ShowReceiptProps = {
+  receiptImage: string | null;
+};
+
+export const ShowReceipt: FC<ShowReceiptProps> = ({ receiptImage }) => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      flexGrow={1}
+      position="relative"
+    >
+      {receiptImage ? (
+        <>
+          <Avatar
+            sx={{
+              width: "100%",
+              height: "100%",
+            }}
+            variant="square"
+          >
+            <img
+              src={receiptImage}
+              style={{
+                maxWidth: "99%", // Avatarの幅に合わせて画像の幅を縮小
+                maxHeight: "99%", // Avatarの高さに合わせて画像の高さを縮小
+                objectFit: "contain", // 画像が見切れないように比率を保って表示
+              }}
+            />
+          </Avatar>
+        </>
+      ) : (
+        <Box
+          sx={{
+            width: "100%",
+            height: "100%",
+            bgcolor: "grey.200",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <p>レシートがありません</p>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/_components/features/expenses/ShowReceipt.tsx
+++ b/src/_components/features/expenses/ShowReceipt.tsx
@@ -3,9 +3,13 @@ import { Box, Avatar } from "@mui/material";
 
 type ShowReceiptProps = {
   receiptImage: string | null;
+  fileName: string | undefined;
 };
 
-export const ShowReceipt: FC<ShowReceiptProps> = ({ receiptImage }) => {
+export const ShowReceipt: FC<ShowReceiptProps> = ({
+  receiptImage,
+  fileName,
+}) => {
   return (
     <Box
       display="flex"
@@ -15,7 +19,7 @@ export const ShowReceipt: FC<ShowReceiptProps> = ({ receiptImage }) => {
       flexGrow={1}
       position="relative"
     >
-      {receiptImage ? (
+      {fileName ? (
         <>
           <Avatar
             sx={{
@@ -24,14 +28,18 @@ export const ShowReceipt: FC<ShowReceiptProps> = ({ receiptImage }) => {
             }}
             variant="square"
           >
-            <img
-              src={receiptImage}
-              style={{
-                maxWidth: "99%", // Avatarの幅に合わせて画像の幅を縮小
-                maxHeight: "99%", // Avatarの高さに合わせて画像の高さを縮小
-                objectFit: "contain", // 画像が見切れないように比率を保って表示
-              }}
-            />
+            {receiptImage ? (
+              <img
+                src={receiptImage}
+                style={{
+                  maxWidth: "99%", // Avatarの幅に合わせて画像の幅を縮小
+                  maxHeight: "99%", // Avatarの高さに合わせて画像の高さを縮小
+                  objectFit: "contain", // 画像が見切れないように比率を保って表示
+                }}
+              />
+            ) : (
+              <p>loading ...</p>
+            )}
           </Avatar>
         </>
       ) : (

--- a/src/_components/features/expenses/index.tsx
+++ b/src/_components/features/expenses/index.tsx
@@ -1,4 +1,5 @@
 import { ExpensesTable } from "@/_components/features/expenses/ExpensesTable";
 import { ExpensesDialog } from "@/_components/features/expenses/ExpenseDialog";
+import { ShowReceipt } from "@/_components/features/expenses/ShowReceipt";
 
-export { ExpensesTable, ExpensesDialog };
+export { ExpensesTable, ExpensesDialog, ShowReceipt };

--- a/src/_components/features/expenses/type.ts
+++ b/src/_components/features/expenses/type.ts
@@ -1,8 +1,9 @@
 export type RowType = {
-  expense_id: string;
+  expenseId: string;
   date: Date;
   storeName: string;
   amount: number;
-  category_id: number;
+  categoryId: number;
   category: string;
+  fileName: string | undefined;
 };

--- a/src/_components/features/sidebar/SidebarServer.ts
+++ b/src/_components/features/sidebar/SidebarServer.ts
@@ -59,7 +59,8 @@ export const getReceiptDetail = async (
   const putPreSignedURL = await generatePreSignedURL(fileName, "put");
   uploadFileToS3(selectedImage, putPreSignedURL);
   const getPreSignedURL = await generatePreSignedURL(fileName, "get");
-  const downloadImg = downloadFileFromS3(getPreSignedURL);
+
+  // TODO: ここでpythonとやりとりできるようにする。
   // NOTE: 一旦以下を返す。
   return {
     storeName: "八百屋",

--- a/src/lib/db/expense.ts
+++ b/src/lib/db/expense.ts
@@ -2,7 +2,11 @@
 
 import prisma from "@/lib/prisma";
 import { cache } from "react";
-import { Expense, FirstExpenseDate, MonthExpensesWithCategory } from "@/types";
+import {
+  Expense,
+  FirstExpenseDate,
+  MonthExpensesWithCategoryReceipt,
+} from "@/types";
 import { da } from "@faker-js/faker";
 
 // 指定した月の出費を取得する
@@ -40,7 +44,7 @@ export const getMonthExpensesWithCategory = cache(
     userId: string,
     firstDay: Date,
     lastDay: Date
-  ): Promise<MonthExpensesWithCategory[]> => {
+  ): Promise<MonthExpensesWithCategoryReceipt[]> => {
     return await prisma.expense.findMany({
       where: {
         date: {
@@ -51,6 +55,7 @@ export const getMonthExpensesWithCategory = cache(
       },
       include: {
         category: true,
+        receipt: true,
       },
       orderBy: {
         date: "desc",

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -81,6 +81,6 @@ export const uploadFileToS3 = async (
   }
 };
 
-export const downloadFileFromS3 = (downloadrePreSignedURL: string) => {
+export const downloadFileFromS3 = async (downloadrePreSignedURL: string) => {
   return "imag_data";
 };

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -80,7 +80,3 @@ export const uploadFileToS3 = async (
     throw new Error("S3へのアップロードに失敗しました");
   }
 };
-
-export const downloadFileFromS3 = async (downloadrePreSignedURL: string) => {
-  return "imag_data";
-};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,20 +1,22 @@
 import { Budget } from "@/types/budget";
 import { Expense, FirstExpenseDate } from "@/types/expense";
 import { Category } from "@/types/category";
+import { Receipt } from "@/types/receipt";
 
-type MonthExpensesWithCategory = Expense & {
+type MonthExpensesWithCategoryReceipt = Expense & {
   category: Category;
+  receipt: Receipt | null;
 };
 
 type MonthBudgetsWithCategory = Budget & {
   category: Category;
-}
+};
 
 export type {
   Budget,
   Expense,
   FirstExpenseDate,
   Category,
-  MonthExpensesWithCategory,
+  MonthExpensesWithCategoryReceipt,
   MonthBudgetsWithCategory,
 };

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -1,0 +1,5 @@
+export type Receipt = {
+  id: string;
+  fileName: string;
+  expenseId: string;
+};


### PR DESCRIPTION
## 概要
出費詳細ページでs3からダウンロードしたレシート画像を表示するようにした

## 詳細タスク
- 出費を取得する際にレシートも取得するようにした。そのため、prismaで取得する時や返り値の型を変更した
  - [✨ 出費に紐づくレシートも取得するようにした (#106)](https://github.com/AyumuOgasawara/receipt-scanner/commit/f39cd5d6c74b07b60b23c1f707b039653d7f0ecd)
  - [🏷️ 月毎の出費の型にレシートの型を追加し、キャメルケースに整えた (#106)](https://github.com/AyumuOgasawara/receipt-scanner/commit/c87489a8263358a086d100e6ba55f1f73259f8e3)
- s3からダウンロードができるようにfileNameがundefinedでないときにgetPreSignedURLを発行した
  - [✨ 取得したレシートがundefinedでないときにgetPreSignedURLを発行するようにした (#106)](https://github.com/AyumuOgasawara/receipt-scanner/commit/8f85ba9d699be820d27f3da9101aa4f61fdf087e)
- レシートを表示するUIを整え、取得したgetPreSignedURLをフロントに返し、表示させた。また、ダイアログが閉じられた際に、セットされていた画像がnullになるようにした
  - [✨ 取得したpreSignedURLをフロントに返し、レシートを表示した。また、ダイアログが閉じるとセットされている画像がnullになるようにした(#108 )](https://github.com/AyumuOgasawara/receipt-scanner/commit/369e87e594b23831709500441a2b38c0ca469339) 

## 動作確認

https://github.com/user-attachments/assets/b1d8ace0-300f-431d-a736-b892550f0722



## 関連タスク
Closes #108 