### PR TITLE
🦺 出費ページの新規作成、更新の際のバリデーションをつけた (#105, #95)

### DIFF
--- a/src/_components/common/Style/style.ts
+++ b/src/_components/common/Style/style.ts
@@ -3,3 +3,4 @@ export const lightgreen = "#b9f6ca";
 export const green = "#00c853";
 export const blue = "#2196f3";
 export const red = "#d50000";
+export const error_red = "#d32f2f";

--- a/src/_components/features/dashboard/LowerDashboard.tsx
+++ b/src/_components/features/dashboard/LowerDashboard.tsx
@@ -2,7 +2,7 @@ import { FC, Suspense } from "react";
 import { Box } from "@mui/material";
 import { BarsDataset } from "@/_components/common/BarsDataset/BarsDataset";
 import { BarsDatasetType } from "@/_components/common/BarsDataset/BarsDataset";
-import { green, blue, red } from "@/_components/features/dashboard/style";
+import { green, blue, red } from "@/_components/common/Style/style";
 
 type LowerDashboardProps = {
   dataset: BarsDatasetType[];

--- a/src/_components/features/dashboard/UpperDashboard.tsx
+++ b/src/_components/features/dashboard/UpperDashboard.tsx
@@ -4,12 +4,7 @@ import { FC, Suspense } from "react";
 
 import { ChartWithLetter } from "@/_components/features/dashboard/ChartWithLetter";
 import { PieChartData } from "@/_components/common/DoughnutPieChart/DoughnutPieChart";
-import {
-  lightgreen,
-  green,
-  blue,
-  red,
-} from "@/_components/features/dashboard/style";
+import { lightgreen, green, blue, red } from "@/_components/common/Style/style";
 import { formatDate } from "@/utils/time";
 
 type remainDaysReturn = {

--- a/src/_components/features/expenses/ExpensesServer.ts
+++ b/src/_components/features/expenses/ExpensesServer.ts
@@ -36,15 +36,11 @@ export const getAndFormatExpenses = async (
 // 特定の出費を更新する
 export const updateSelectedExpense = async (
   expenseId: string,
-  dateStr: string,
+  date: Date,
   storeName: string,
   amount: number,
   categoryId: number
 ) => {
-  const date = formatStrDate(dateStr);
-  if (date === undefined) {
-    throw new Error("The date is invalid");
-  }
   try {
     await updateExpense(expenseId, amount, storeName, date, categoryId);
   } catch (error) {

--- a/src/_components/features/expenses/ExpensesTable.tsx
+++ b/src/_components/features/expenses/ExpensesTable.tsx
@@ -107,19 +107,20 @@ export const ExpensesTable: FC<ExpensesTableProps> = ({
           </TableBody>
         </Table>
       </TableContainer>
-
-      <ExpensesDialog
-        handleClose={handleClose}
-        open={open}
-        selectedItem={selectedItem}
-        categories={categories}
-        userId={userId}
-        firstDay={firstDay}
-        lastDay={lastDay}
-        getExpensesAndSetRows={getExpensesAndSetRows}
-        receiptImage={receiptImage}
-        setReceiptImage={setReceiptImage}
-      />
+      {selectedItem && (
+        <ExpensesDialog
+          handleClose={handleClose}
+          open={open}
+          selectedItem={selectedItem}
+          categories={categories}
+          userId={userId}
+          firstDay={firstDay}
+          lastDay={lastDay}
+          getExpensesAndSetRows={getExpensesAndSetRows}
+          receiptImage={receiptImage}
+          setReceiptImage={setReceiptImage}
+        />
+      )}
     </Box>
   );
 };

--- a/src/_components/features/sidebar/AddExpenseDetail.tsx
+++ b/src/_components/features/sidebar/AddExpenseDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import {
   TextField,
   Box,
@@ -14,15 +14,18 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import { Category } from "@/types";
 import { ExpenseDetail } from "@/_components/features/sidebar/type";
+import { error_red } from "@/_components/common/Style/style";
 
 type AddExpenseDetailProps = {
   expenseDetailUseState: ExpenseDetail;
   categories: Category[];
+  setIsCreateDisabled: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const AddExpenseDetail: FC<AddExpenseDetailProps> = ({
   expenseDetailUseState,
   categories,
+  setIsCreateDisabled,
 }) => {
   const {
     expenseDate,
@@ -34,6 +37,28 @@ export const AddExpenseDetail: FC<AddExpenseDetailProps> = ({
     categoryId,
     setCategoryId,
   } = expenseDetailUseState;
+
+  // エラー状態の管理
+  const [storeNameError, setStoreNameError] = useState(false);
+  const [amountError, setAmountError] = useState(false);
+
+  // バリデーションチェック関数
+  const validateFields = () => {
+    const isStoreNameValid = storeName.trim() !== "";
+    const isAmountValid = amount > 0;
+
+    setStoreNameError(!isStoreNameValid);
+    setAmountError(!isAmountValid);
+
+    // 作成ボタンの有効/無効を親コンポーネントに伝える
+    setIsCreateDisabled(!(isStoreNameValid && isAmountValid));
+  };
+
+  // 入力が変更されるたびにバリデーションを実行
+  useEffect(() => {
+    validateFields();
+  }, [storeName, amount]);
+
   return (
     <Box
       display="flex"
@@ -68,15 +93,37 @@ export const AddExpenseDetail: FC<AddExpenseDetailProps> = ({
         variant="filled"
         value={storeName}
         onChange={(e) => setStoreName(e.target.value)}
+        error={storeNameError} // エラー表示
+        helperText={storeNameError ? "必須項目です。" : ""}
       />
       <FormControl sx={{ minWidth: 120, mb: 1, ml: 1 }} variant="filled">
-        <InputLabel id="amount">金額</InputLabel>
+        <InputLabel
+          id="amount"
+          sx={{
+            color: amountError ? error_red : "inherit",
+          }}
+        >
+          金額
+        </InputLabel>
         <FilledInput
           startAdornment={<InputAdornment position="start">¥</InputAdornment>}
           type="number"
           value={amount}
           onChange={(e) => setAmount(Number(e.target.value))}
+          error={amountError}
         />
+        {amountError && (
+          <span
+            style={{
+              color: error_red, // エラーカラー
+              fontSize: "0.75rem", // TextFieldのhelperTextと同じフォントサイズ
+              marginLeft: "14px", // TextFieldのhelperTextと同じ左余白
+              marginTop: "3px", // エラーメッセージの上に少し余白
+            }}
+          >
+            必須項目です。
+          </span>
+        )}
       </FormControl>
       <FormControl sx={{ minWidth: 120, mb: 1, ml: 1 }}>
         <InputLabel variant="filled">カテゴリー</InputLabel>

--- a/src/_components/features/sidebar/AddExpenseDetail.tsx
+++ b/src/_components/features/sidebar/AddExpenseDetail.tsx
@@ -66,7 +66,6 @@ export const AddExpenseDetail: FC<AddExpenseDetailProps> = ({
       component="form"
       sx={{ "& .MuiTextField-root": { mb: 1, ml: 1 } }}
     >
-      {/* TODO: 全ての要素がrequiredでなければならない */}
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DemoContainer components={["DatePicker"]}>
           <DatePicker

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -17,6 +17,7 @@ import {
 import {
   formatAndCreateExpense,
   getReceiptDetail,
+  checkFileNameExists,
 } from "@/_components/features/sidebar/SidebarServer";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
@@ -56,10 +57,19 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     setFileName,
   } = expenseDetailUseState;
 
-  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const file = event.target.files?.[0];
 
     if (file) {
+      const fileNameExists = await checkFileNameExists(file.name);
+      if (fileNameExists) {
+        alert(
+          "このファイル名はすでに使用されています。別のファイル名を選択してください。"
+        );
+        return;
+      }
       setFileName(file.name);
       const reader = new FileReader();
       reader.onloadend = () => {

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -56,6 +56,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     fileName,
     setFileName,
   } = expenseDetailUseState;
+  const [isCreateDisabled, setIsCreateDisabled] = useState(false);
 
   const handleImageUpload = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -139,6 +140,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
           <AddExpenseDetail
             categories={categories}
             expenseDetailUseState={expenseDetailUseState}
+            setIsCreateDisabled={setIsCreateDisabled}
           />
         </Box>
       </DialogContent>
@@ -181,6 +183,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
             variant="contained"
             sx={{ fontWeight: "bold" }}
             onClick={handleCreateExpense}
+            disabled={isCreateDisabled}
           >
             作成
           </Button>

--- a/src/_components/features/sidebar/SidebarServer.ts
+++ b/src/_components/features/sidebar/SidebarServer.ts
@@ -3,12 +3,8 @@ import {
   ReceiptDetail,
 } from "@/_components/features/sidebar/type";
 import { formatDate } from "@/utils/time";
-import { createExpense } from "@/lib/db";
-import {
-  uploadFileToS3,
-  downloadFileFromS3,
-  generatePreSignedURL,
-} from "@/lib/s3";
+import { createExpense, isFileNameExists } from "@/lib/db";
+import { uploadFileToS3, generatePreSignedURL } from "@/lib/s3";
 
 // 最初の月から今日までの年月をリストにする
 export const getDatesInRange = (
@@ -83,4 +79,8 @@ export const formatAndCreateExpense = async (
   } catch (error) {
     throw error;
   }
+};
+
+export const checkFileNameExists = async (fileName: string) => {
+  return await isFileNameExists(fileName);
 };

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -8,6 +8,7 @@ import {
   createExpense,
 } from "@/lib/db/expense";
 import { getCategories } from "@/lib/db/category";
+import { isFileNameExists } from "@/lib/db/receipt";
 
 export {
   getMonthBudgets,
@@ -19,4 +20,5 @@ export {
   getCategories,
   getMonthExpensesWithCategory,
   getMonthBudgetsWithCategory,
+  isFileNameExists,
 };

--- a/src/lib/db/receipt.ts
+++ b/src/lib/db/receipt.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+import { cache } from "react";
+
+export const isFileNameExists = cache(
+  async (fileName: string): Promise<boolean> => {
+    const receipt = await prisma.receipt.findUnique({
+      where: {
+        fileName: fileName,
+      },
+    });
+    return !!receipt; // すでに存在する場合 true を返す
+  }
+);


### PR DESCRIPTION
## 概要
出費の新規作成ページのレシートのアップロードと、店名と金額に、更新ページの店名と金額にのバリデーションをつけた。

## 実装詳細
- レシートはユニークのため、すでに同じファイル名がある場合にはfileNameがセットされないようにした 
  - [🥅 レシートのgfileNameがすでにある際には画像がセットされないようにした (#105)](https://github.com/AyumuOgasawara/receipt-scanner/commit/cb00108327a4312c4b1667e46f9a3ec27729aa34)
- エラーメッセージの色をstyle.tsとして持ちたかったため、commonコンポーネントにstyle.tsを作成し、色はそこから取得するようにした。
  - [💄 commonコンポーネントにsytleの色を追加した (#105)](https://github.com/AyumuOgasawara/receipt-scanner/commit/512610abcedc6186b0bb1fd7f2049a17e93db746)
- [🦺 新規追加ページの店名と金額にバリデーションをつけた (#105)](https://github.com/AyumuOgasawara/receipt-scanner/commit/a89d9ff0c21ad9f9533b798455b1c38bb71ce9e9)
- 出費更新ページでは、親コンポーネントで選択されたものをSlectedItemとして渡していたが、ダイアログに表示されるのは選択されている時のみだから、selectedItemのnullの可能性をなくした
  - [🦺 出費の更新ページでバリデーションを店名と金額にバリデーションをつけた (#105, #95)](https://github.com/AyumuOgasawara/receipt-scanner/commit/8b33349584864ee4282df98cc0c0362d2b871afa)

## 動作確認
レシート && 出費の追加

https://github.com/user-attachments/assets/d63e9f67-7e63-49f8-a693-658546be94cd



出費の更新


https://github.com/user-attachments/assets/94682f2e-4995-4082-bad9-18c44cfa49c0

## 関連タスク
Closes #105 , Closes #95 