### PR TITLE
✨ Pythonの画像解析APIを叩き、レシート解析を行うと解析結果が反映されるようにした (#111)

### DIFF
--- a/src/_components/features/expenses/ExpensesServer.ts
+++ b/src/_components/features/expenses/ExpensesServer.ts
@@ -6,7 +6,6 @@ import {
   deleteExpense,
 } from "@/lib/db";
 import { RowType } from "@/_components/features/expenses/type";
-import { formatStrDate } from "@/utils/time";
 import { generatePreSignedURL } from "@/lib/s3";
 
 export const getAndFormatExpenses = async (

--- a/src/_components/features/sidebar/AddExpenseDetail.tsx
+++ b/src/_components/features/sidebar/AddExpenseDetail.tsx
@@ -7,6 +7,7 @@ import {
   InputLabel,
   FilledInput,
   InputAdornment,
+  Typography,
 } from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
@@ -139,6 +140,9 @@ export const AddExpenseDetail: FC<AddExpenseDetailProps> = ({
           ))}
         </Select>
       </FormControl>
+      <Typography variant="caption" gutterBottom sx={{ mb: 1, ml: 1 }}>
+        ※解析には2秒程かかります。
+      </Typography>
     </Box>
   );
 };

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -103,14 +103,14 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     if (selectedImage && fileName) {
       const analyzedReceiptDate = await getReceiptDetail(
         selectedImage,
-        fileName
+        fileName,
+        categories
       );
       setExpenseDate(analyzedReceiptDate.date); // 解析された日付をセット
       setStoreName(analyzedReceiptDate.storeName); // 解析された店名をセット
       setAmount(analyzedReceiptDate.amount); // 解析された金額をセット
       setCategoryId(analyzedReceiptDate.category); // 解析されたカテゴリをセット
     }
-    console.log("解析");
   };
 
   const handleImageRemove = () => {

--- a/src/utils/analyzeReceipt.ts
+++ b/src/utils/analyzeReceipt.ts
@@ -1,0 +1,47 @@
+"use server";
+
+type PreSignedURL = {
+  pre_signed_url: string;
+};
+
+type Error = {
+  code: number;
+  message: string;
+};
+
+type AnalyzedReceiptDetail = {
+  store_name: string | null;
+  amount: number;
+  date: string | null;
+  category: string | null;
+};
+
+type ReceiptAnalyzationResponse = {
+  receipt_detail: AnalyzedReceiptDetail | null;
+  error: Error | null;
+};
+
+export const getReceiptDetailFromModel = async (
+  preSignedURL: string
+): Promise<ReceiptAnalyzationResponse> => {
+  const body: PreSignedURL = {
+    pre_signed_url: preSignedURL,
+  };
+
+  const response = await fetch(
+    `${process.env.PYTHON_API_SERVER}/receipt-analyze`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json", // ここでContent-Typeを指定
+      },
+      body: JSON.stringify(body), // bodyをheadersの外に移動
+    }
+  ).catch((error) => {
+    console.log(error);
+    throw error;
+  });
+
+  const analyzationResponse: ReceiptAnalyzationResponse = await response.json();
+  return analyzationResponse;
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -36,7 +36,7 @@ export const formatDate = (
 
 export const formatStrDate = (dateStr: string): Date | undefined => {
   // 正規表現で年、月、日を抽出
-  const dateParts = dateStr.match(/(\d{4})年(\d{1,2})月(\d{1,2})/);
+  const dateParts = dateStr.match(/(\d{4})\/(\d{1,2})\/(\d{1,2})/);
 
   // 年、月、日を抽出してDateオブジェクトに変換
   if (dateParts) {


### PR DESCRIPTION
## 概要
解析ボタンを押下後にPython側のAP Iに向けてPOSTを行う。
返ってきた値をフロントで使いやすいように変換して、フロントに返す。
結果、解析し、解析結果がフロントに反映されるようになった。

## 動作確認
https://github.com/user-attachments/assets/e742ff6f-6e27-412e-a441-c9df796cb38a

