### PR TITLE
💄 サイドバーのレイアウトを整えた (#88)

### DIFF
--- a/src/_components/common/Style/style.ts
+++ b/src/_components/common/Style/style.ts
@@ -4,3 +4,4 @@ export const green = "#00c853";
 export const blue = "#2196f3";
 export const red = "#d50000";
 export const error_red = "#d32f2f";
+export const gray = "rgba(0, 0, 0, 0.23)";

--- a/src/_components/features/sidebar/Sidebar.tsx
+++ b/src/_components/features/sidebar/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/_components/features/sidebar/type";
 import { Category } from "@/types";
 import { CreateExpenseDialog } from "@/_components/features/sidebar/CreateExpenseDialog";
+import { gray } from "@/_components/common/Style/style";
 
 const drawerWidth = "20%";
 
@@ -110,19 +111,43 @@ export const Sidebar: FC<SidebarProps> = ({
       sx={{
         width: drawerWidth,
         flexShrink: 0,
-        [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: "border-box" },
+        [`& .MuiDrawer-paper`]: {
+          width: drawerWidth,
+          boxSizing: "border-box",
+          maxWidth: 250,
+          minWidth: 80,
+        },
       }}
     >
       {/* ヘッダー分ずらす */}
-      <Box paddingTop={8}>
-        <FormControl sx={{ m: 1, minWidth: 80, textAlign: "center" }}>
+      <Box
+        paddingTop={8}
+        sx={{
+          paddingX: 2,
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+        }}
+      >
+        <FormControl sx={{ marginY: 2, width: "100%", textAlign: "center" }}>
           <Select autoWidth value={selectedPage} onChange={handlePageChange}>
             <MenuItem value={"dashboard"}>ダッシュボード</MenuItem>
             <MenuItem value={"expenses"}>全ての出費</MenuItem>
             <MenuItem value={"budgets"}>予算の編集</MenuItem>
           </Select>
         </FormControl>
-        <Button variant="outlined" onClick={handleShowCreateDialog}>
+        <Button
+          variant="outlined"
+          onClick={handleShowCreateDialog}
+          sx={{
+            marginBottom: 2,
+            color: "black",
+            borderColor: gray,
+            "&:hover": {
+              borderColor: "black",
+            },
+          }}
+        >
           <AddCircleOutlineIcon sx={{ m: 2 }} />
           出費を追加
         </Button>
@@ -136,7 +161,9 @@ export const Sidebar: FC<SidebarProps> = ({
           router={router}
           expenseDetailUseState={expenseDetailUseState}
         />
-        <FormControl sx={{ m: 1, minWidth: 80, textAlign: "center" }}>
+        <FormControl
+          sx={{ marginBottom: 2, width: "100%", textAlign: "center" }}
+        >
           <Select
             // 最後の月をでファルとに選択 → 必然的に今月
             value={selectedDate}
@@ -150,23 +177,22 @@ export const Sidebar: FC<SidebarProps> = ({
             ))}
           </Select>
         </FormControl>
-        <Box sx={{ m: 1, minWidth: 80 }}>
-          <Card variant="outlined">
-            <React.Fragment>
-              <CardContent>
-                <Typography
-                  gutterBottom
-                  sx={{ color: "text.secondary", fontSize: 14 }}
-                >
-                  {foramtedToday}の一言
-                </Typography>
-                <Typography variant="h5" component="div">
-                  {proverb}
-                </Typography>
-              </CardContent>
-            </React.Fragment>
-          </Card>
-        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <Card variant="outlined" sx={{ marginTop: "auto", marginBottom: 16 }}>
+          <React.Fragment>
+            <CardContent>
+              <Typography
+                gutterBottom
+                sx={{ color: "text.secondary", fontSize: 14 }}
+              >
+                {foramtedToday}の一言
+              </Typography>
+              <Typography variant="h5" component="div">
+                {proverb}
+              </Typography>
+            </CardContent>
+          </React.Fragment>
+        </Card>
       </Box>
     </Drawer>
   );


### PR DESCRIPTION
## 概要
以下を実装し、サイドバーを整えた
- サイドバーのサイズにminWidthとmaxWidthを設定した
- 中のコンポーネントのサイズのwidthを100%にした
- 名言カードを下揃えにし、後のものを上揃えにした

## 動作確認
<img width="1438" alt="スクリーンショット 2024-10-26 11 32 12" src="https://github.com/user-attachments/assets/e9edf6b1-2e15-4cd0-884e-05557d4120b8">


## 関連タスク
Closes #88 