### PR TITLE
Issue/133

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
     `npm install`
 
 - aws アカウントを作成し、IAM ユーザーを作成する
-  - 作者は`AdministratorAccess`と`AWSCompromisedKeyQuarantineV3`をポリシーとして割り当てているが、S3 からデータのダウンロードとアップ絵オードができるポリシーがあれば良い。
+  - 作者は`AdministratorAccess`と`AmazonS3FullAccess`をポリシーとして割り当てている、権限の範囲などを考慮して」設定する。
   - S3 に`receipt-scanner`というバケットを作成し、[こちら](https://github.com/AyumuOgasawara/receipt-scanner-model/issues/28#issuecomment-2419930774)を参考にバケットポリシーを作成する。
 - Google OAuth の設定
   - [こちら](https://next-auth.js.org/providers/google)を参考に`OAuth 2.0 クライアント ID`を作成し、以下を設定する
@@ -156,4 +156,3 @@ receipt-scanner/
 
 レシート解析<br>
 ![378206844-e742ff6f-6e27-412e-a441-c9df796cb38a-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/839a25bb-14d2-4795-8cee-412a4bc69fd8)
-

--- a/src/_components/features/sidebar/SidebarServer.ts
+++ b/src/_components/features/sidebar/SidebarServer.ts
@@ -56,7 +56,7 @@ export const getReceiptDetail = async (
   categories: Category[]
 ): Promise<ReceiptDetail> => {
   const putPreSignedURL = await generatePreSignedURL(fileName, "put");
-  uploadFileToS3(selectedImage, putPreSignedURL);
+  await uploadFileToS3(selectedImage, putPreSignedURL);
   const getPreSignedURL = await generatePreSignedURL(fileName, "get");
 
   const receiptDetail = await getReceiptDetailFromModel(getPreSignedURL);


### PR DESCRIPTION
## 概要
レシートが解析できなかったため、その原因を突き止め、修正した。

## 原因
エラーを遡るとアプリ側ではなく、API側でエラーが起きていることがわかった。
権限で失敗していたため、IAMユーザーとS3バケットのポリシーを見返した。
すると、`AWSCompromisedKeyQuarantineV3 `で、GetObjectをDenyするポリシーが追加されていた。
そのため、そのポリシーを削除するとうまくいった。

## 関連するコミット
- uploadFileToS3をawaitするようにした。
- ポリシーを更新したため、READMEを変更した。

## 関連タスク
Closes #133

## 動作確認

https://github.com/user-attachments/assets/145a1b67-dcba-4c22-a259-bf9f5f5fabd5


