### PR TITLE
🐛 Prisma Clientの実行環境にdebian-openssl-3.0.xを追加した

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,8 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## 概要
prisma schemaのbinaryTargetsにdebian-openssl-3.0.xを追加し、デプロイした際の実行環境に合わせた。

それによって、認証後のエラーがなくなるようにした。

## 関連タスク
Closes #139 

## 動作確認
認証後にPrismaの以下のエラーがなくなった。
`Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x".`