### PR TITLE
✨standaloneをnext.configに追加した (#)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   images: {
     remotePatterns: [{ hostname: "lh3.googleusercontent.com" }],
   },
-  trailingSlash: false
+  trailingSlash: false,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要
ビルド後にserver.jsを実行できるように、 standaloneで実行する

公式を参考にして行なった。

https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile


## 動作確認
next.config.mjsを以下のようにすると、.next/standalone/server.js が作成された。
node sever.jsを実行するとうまく起動した。